### PR TITLE
Fix: the lexvo language validator to no check the iso version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 4)
@@ -248,4 +249,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.12
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
-    base64 (0.1.1)
     bcrypt (3.1.19)
     builder (3.2.4)
     coderay (1.1.3)
@@ -46,7 +45,7 @@ GEM
       rexml
     cube-ruby (0.0.3)
     daemons (1.4.1)
-    date (3.3.3)
+    date (3.3.4)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -94,7 +93,7 @@ GEM
     launchy (2.5.2)
       addressable (~> 2.8)
     libxml-ruby (2.9.0)
-    logger (1.5.3)
+    logger (1.6.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
     mail (2.8.1)
@@ -116,12 +115,12 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.3.0)
     net-http-persistent (2.9.4)
-    net-imap (0.4.1)
+    net-imap (0.4.4)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0)
       net-protocol
@@ -141,7 +140,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (1.6.13)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
@@ -149,9 +148,9 @@ GEM
     rake (10.5.0)
     rdf (1.0.8)
       addressable (>= 2.2)
-    redis (5.0.7)
-      redis-client (>= 0.9.0)
-    redis-client (0.17.0)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
+    redis-client (0.18.0)
       connection_pool
     regexp_parser (2.8.2)
     request_store (1.5.1)
@@ -164,8 +163,7 @@ GEM
     rexml (3.2.6)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.57.1)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -176,7 +174,7 @@ GEM
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -198,11 +196,11 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thread_safe (0.3.6)
-    timeout (0.4.0)
+    timeout (0.4.1)
     tzinfo (0.3.62)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9)
     unicode-display_width (2.5.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -213,6 +211,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -249,4 +248,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.26
+   2.4.21

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
@@ -74,9 +74,9 @@ module LinkedData
         def lexvo_language(inst, attr)
           values = Array(attr_value(inst, attr))
 
-          return if values.all? { |x| x&.to_s&.start_with?('http://lexvo.org/id/iso639-3') }
+          return if values.all? { |x| x&.to_s&.start_with?('http://lexvo.org/id/iso') }
 
-          [:lexvo_language, "#{attr} values need to be in the lexvo namespace (e.g http://lexvo.org/id/iso639-3/fra)"]
+          [:lexvo_language, "#{attr} values need to be in the lexvo namespace (e.g http://lexvo.org/id/iso639-1/fr)"]
         end
 
         def deprecated_retired_align(inst, attr)

--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -23,31 +23,6 @@ module LinkedData
       write_access :creator
       access_control_load :creator
 
-      def usages
-        id = self.id
-        q = Goo.sparql_query_client.select(:id, :property, :status).distinct
-               .from(LinkedData::Models::OntologySubmission.uri_type)
-               .where(
-                 [:id,
-                  RDF::URI.new('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
-                  LinkedData::Models::OntologySubmission.uri_type
-                 ],
-                 [:id,
-                  LinkedData::Models::OntologySubmission.attribute_uri(:submissionStatus),
-                  :status
-                 ]
-               )
-
-        q = q.union([[:id, :property, id]])
-        q.filter("?status = <#{RDF::URI.new(LinkedData::Models::SubmissionStatus.id_prefix + 'RDF')}> || ?status = <#{RDF::URI.new(LinkedData::Models::SubmissionStatus.id_prefix + 'UPLOADED')}>")
-        data = q.each_solution.map { |x| [x[:id], x[:property], x[:status]] }
-        data = data.group_by(&:shift)
-        data.transform_values do |values|
-          r = values.select { |value| value.last['RDF'] }
-          r = values.select { |value| value.last['UPLOADED'] } if r.empty?
-          r.map(&:first)
-        end
-      end
 
       def self.load_agents_usages(agents = [])
         is_a = RDF::URI.new('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')

--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -16,13 +16,38 @@ module LinkedData
       attribute :identifiers, namespace: :adms, property: :identifier, enforce: %i[Identifier list unique_identifiers]
       attribute :affiliations, enforce: %i[Agent list is_organization], namespace: :org, property: :memberOf
       attribute :creator, type: :user, enforce: [:existence]
-
       embed :identifiers, :affiliations
       embed_values affiliations: LinkedData::Models::Agent.goo_attrs_to_load + [identifiers: LinkedData::Models::AgentIdentifier.goo_attrs_to_load]
+      serialize_methods :usages
 
       write_access :creator
       access_control_load :creator
 
+      def usages
+        id = self.id
+        q = Goo.sparql_query_client.select(:id, :property, :status).distinct
+               .from(LinkedData::Models::OntologySubmission.uri_type)
+               .where(
+                 [:id,
+                  RDF::URI.new('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+                  LinkedData::Models::OntologySubmission.uri_type
+                 ],
+                 [:id,
+                  LinkedData::Models::OntologySubmission.attribute_uri(:submissionStatus),
+                  :status
+                 ]
+               )
+
+        q = q.union([[:id, :property, id]])
+        q.filter("?status = <#{RDF::URI.new(LinkedData::Models::SubmissionStatus.id_prefix + 'RDF')}> || ?status = <#{RDF::URI.new(LinkedData::Models::SubmissionStatus.id_prefix + 'UPLOADED')}>")
+        data = q.each_solution.map { |x| [x[:id], x[:property], x[:status]] }
+        data = data.group_by(&:shift)
+        data.transform_values do |values|
+          r = values.select { |value| value.last['RDF'] }
+          r = values.select { |value| value.last['UPLOADED'] } if r.empty?
+          r.map(&:first)
+        end
+      end
 
       def unique_identifiers(inst, attr)
         inst.bring(attr) if inst.bring?(attr)

--- a/test/models/test_agent.rb
+++ b/test/models/test_agent.rb
@@ -3,8 +3,9 @@ require_relative "../test_case"
 class TestAgent < LinkedData::TestCase
 
   def self.before_suite
+    backend_4s_delete
     self.new("before_suite").teardown
-    @@user1 = LinkedData::Models::User.new(:username => "user11111", :email => "some1111@email.org" )
+    @@user1 = LinkedData::Models::User.new(:username => "user11111", :email => "some1111@email.org")
     @@user1.passwordHash = "some random pass hash"
     @@user1.save
   end
@@ -15,32 +16,28 @@ class TestAgent < LinkedData::TestCase
     @@user1.delete
   end
 
-
-
   def test_agent_no_valid
 
-    @agents =[
-      LinkedData::Models::Agent.new(name:"name 0", email:"test_0@test.com", agentType: 'organization',creator: @@user1 ),
-      LinkedData::Models::Agent.new(name:"name 1", email:"test_1@test.com", agentType: 'person', creator: @@user1 ),
-      LinkedData::Models::Agent.new(name:"name 2", email:"test_2@test.com",  agentType: 'person', creator: @@user1 )
+    @agents = [
+      LinkedData::Models::Agent.new(name: "name 0", email: "test_0@test.com", agentType: 'organization', creator: @@user1),
+      LinkedData::Models::Agent.new(name: "name 1", email: "test_1@test.com", agentType: 'person', creator: @@user1),
+      LinkedData::Models::Agent.new(name: "name 2", email: "test_2@test.com", agentType: 'person', creator: @@user1)
     ]
     @identifiers = [
       LinkedData::Models::AgentIdentifier.new(notation: '000h6jb29', schemaAgency: 'ROR', creator: @@user1),
       LinkedData::Models::AgentIdentifier.new(notation: '000h6jb29', schemaAgency: 'ORCID', creator: @@user1),
     ]
 
-    @identifiers.each {|i| i.save}
+    @identifiers.each { |i| i.save }
 
-    affiliations = @agents[0..2].map{ |a| a.save }
+    affiliations = @agents[0..2].map { |a| a.save }
     agent = @agents.last
     agent.affiliations = affiliations
-
 
     refute agent.valid?
     refute_nil agent.errors[:affiliations][:is_organization]
 
-    affiliations.each{|x| x.delete}
-
+    affiliations.each { |x| x.delete }
 
     agents = @agents[0..2].map do |a|
       a.identifiers = @identifiers
@@ -54,8 +51,7 @@ class TestAgent < LinkedData::TestCase
     refute second_agent.valid?
     refute_nil second_agent.errors[:identifiers][:unique_identifiers]
 
-
-    @identifiers.each{|i| i.delete}
+    @identifiers.each { |i| i.delete }
   end
 
   def test_identifier_find
@@ -69,6 +65,7 @@ class TestAgent < LinkedData::TestCase
 
     id.delete
   end
+
   def test_identifier_no_valid
     refute LinkedData::Models::AgentIdentifier.new(notation: 'https://ror.org/000h6jb29', schemaAgency: 'ROR', creator: @@user1).valid?
     id = LinkedData::Models::AgentIdentifier.new(notation: '000h6jb29"', schemaAgency: 'ROR', creator: @@user1)
@@ -82,4 +79,58 @@ class TestAgent < LinkedData::TestCase
     id.delete
   end
 
+  def test_agent_usages
+    count, acronyms, ontologies = create_ontologies_and_submissions(ont_count: 3, submission_count: 1,
+                                                                    process_submission: false)
+
+    o1 = ontologies[0]
+    o2 = ontologies[1]
+    o3 = ontologies[2]
+    sub1 = o1.latest_submission(status: :any)
+    sub2 = o2.latest_submission(status: :any)
+    sub3 = o3.latest_submission(status: :any)
+    refute_nil sub1
+    refute_nil sub2
+    refute_nil sub3
+
+    agents = [LinkedData::Models::Agent.new(name: "name 0", email: "test_0@test.com", agentType: 'organization', creator: @@user1).save,
+              LinkedData::Models::Agent.new(name: "name 1", email: "test_1@test.com", agentType: 'organization', creator: @@user1).save,
+              LinkedData::Models::Agent.new(name: "name 2", email: "test_2@test.com", agentType: 'person', creator: @@user1).save]
+
+    sub1.hasCreator = [agents.last]
+    sub1.publisher = agents[0..1]
+    sub1.fundedBy = [agents[0]]
+    sub1.bring_remaining
+    assert sub1.valid?
+    sub1.save
+
+    sub2.hasCreator = [agents.last]
+    sub2.endorsedBy = [agents[0]]
+    sub2.fundedBy = agents[0..1]
+    sub2.bring_remaining
+    assert sub2.valid?
+    sub2.save
+
+    usages = agents[0].usages
+
+    assert_equal 2, usages.size
+
+    refute_nil usages[sub1.id]
+    assert_equal usages[sub1.id].map(&:to_s).sort, ["http://purl.org/dc/terms/publisher", "http://xmlns.com/foaf/0.1/fundedBy"].sort
+    refute_nil usages[sub2.id].map(&:to_s).sort, ["http://omv.ontoware.org/2005/05/ontology#endorsedBy", "http://xmlns.com/foaf/0.1/fundedBy"].sort
+
+    sub3.copyrightHolder = agents[0]
+    sub3.bring_remaining
+    sub3.save
+
+    usages = agents[0].usages
+    assert_equal 3, usages.size
+
+    refute_nil usages[sub1.id]
+    assert_equal usages[sub1.id].map(&:to_s).sort, ["http://purl.org/dc/terms/publisher", "http://xmlns.com/foaf/0.1/fundedBy"].sort
+    assert_equal usages[sub2.id].map(&:to_s).sort, ["http://omv.ontoware.org/2005/05/ontology#endorsedBy", "http://xmlns.com/foaf/0.1/fundedBy"].sort
+    assert_equal usages[sub3.id].map(&:to_s), ["http://schema.org/copyrightHolder"]
+
+    agents.each{|x| x.delete}
+  end
 end


### PR DESCRIPTION
We update the natural language namespace from `http://lexvo.org/id/iso639-3` to `http://lexvo.org/id/iso639-1`, this PR updates the language validator to accept that.