### PR TITLE
Fix: update submission yaml file for released, creationDate, uriRegexPattern 

### DIFF
--- a/config/schemes/ontology_submission.yml
+++ b/config/schemes/ontology_submission.yml
@@ -412,7 +412,7 @@ publication:
 ### Dates
 
 #Creation date
-creationDate:
+released:
   display: "dates"
   label: "Creation date"
   helpText: "Date of original (or first) creation of the resource."
@@ -466,7 +466,7 @@ curatedOn:
   metadataMappings: [ "pav:curatedOn" ]
 
 #Submission date 
-released:
+creationDate:
   display: "dates"
   label: "Submission date"
   helpText: "Date of the submission/release in the portal."

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -149,7 +149,7 @@ module LinkedData
       attribute :translationOfWork, namespace: :schema, type: %i[uri list]
 
       # Content metadata
-      attribute :uriRegexPattern, namespace: :void, type: :uri
+      attribute :uriRegexPattern, namespace: :void
       attribute :preferredNamespaceUri, namespace: :vann, type: :uri
       attribute :preferredNamespacePrefix, namespace: :vann
       attribute :exampleIdentifier, namespace: :idot

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -32,7 +32,7 @@ module LinkedData
         submission.bring_remaining
         ontology = submission.ontology
         ontology.bring(:name, :acronym)
-        result = submission.ready? ? 'Success' : 'Failure'
+        result = submission.ready? || submission.archived? ? 'Success' : 'Failure'
         status = LinkedData::Models::SubmissionStatus.readable_statuses(submission.submissionStatus)
 
         subject = "[#{LinkedData.settings.ui_name}] #{ontology.name} Parsing #{result}"

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1149,9 +1149,10 @@ eos
       assert_equal ["http://lexvo.org/id/iso639-3/fra", "http://lexvo.org/id/iso639-3/eng"].sort, sub.naturalLanguage.sort
       #assert_equal ["Léontine Dessaiterm", "Anne Toulet", "Benjamine Dessay", "Augustine Doap", "Vincent Emonet"].sort, sub.hasContributor.sort
       assert_equal [RDF::URI.new("http://lirmm.fr/2015/ontology/door-relation.owl"), RDF::URI.new("http://lirmm.fr/2015/ontology/dc-relation.owl"),
-                    RDF::URI.new("http://lirmm.fr/2015/ontology/dcterms-relation.owl"), RDF::URI.new("http://lirmm.fr/2015/ontology/voaf-relation.owl")].sort, sub.ontologyRelatedTo.sort
-
-
+                    RDF::URI.new("http://lirmm.fr/2015/ontology/dcterms-relation.owl"),
+                    RDF::URI.new("http://lirmm.fr/2015/ontology/voaf-relation.owl"),
+                    RDF::URI.new("http://lirmm.fr/2015/ontology/void-import.owl")
+                   ].sort, sub.ontologyRelatedTo.sort
       sub.description = "test changed value"
       sub.save
     end


### PR DESCRIPTION
### Changes
* fix error btw released and creationDate (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/ae5b86a20b60b7c5362be4b1b20f6be302648b4c)
* open the uriRegexPattern property to be a string (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/c2cd9cb5015a1c75a1aa68729fe32a9b525bace6)
* fix archived submission notification email to show failure in subject (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/c74279d3ad080b61fe7c1343fbaca09d4f286e0d)