### PR TITLE
Fix: Google analytics new version and add users analytics 

### DIFF
--- a/lib/ontologies_linked_data/concerns/analytics.rb
+++ b/lib/ontologies_linked_data/concerns/analytics.rb
@@ -1,0 +1,52 @@
+module LinkedData
+  module Concerns
+    module Analytics
+      def self.included base
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def load_data(field_name)
+          @@redis ||= Redis.new(:host => LinkedData.settings.ontology_analytics_redis_host,
+                                :port => LinkedData.settings.ontology_analytics_redis_port,
+                                :timeout => 30)
+          raw_data = @@redis.get(field_name)
+          raw_data.nil? ? Hash.new : Marshal.load(raw_data)
+        end
+
+        def analytics_redis_key
+          raise NotImplementedError # the class that includes it need to implement it
+        end
+
+        def load_analytics_data
+          self.load_data(analytics_redis_key)
+        end
+
+        def analytics(year = nil, month = nil)
+          retrieve_analytics(year, month)
+        end
+
+        # A static method for retrieving Analytics for a combination of ontologies, year, month
+        def retrieve_analytics(year = nil, month = nil)
+          analytics = self.load_analytics_data
+
+          year = year.to_s if year
+          month = month.to_s if month
+
+          unless analytics.empty?
+            analytics.values.each do |ont_analytics|
+              ont_analytics.delete_if { |key, _| key != year } unless year.nil?
+              ont_analytics.each { |_, val| val.delete_if { |key, __| key != month } } unless month.nil?
+            end
+            # sort results by the highest traffic values
+            analytics = Hash[analytics.sort_by { |_, v| v[year][month] }.reverse] if year && month
+          end
+          analytics
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -10,6 +10,10 @@ module LinkedData
       include BCrypt
       include LinkedData::Models::Users::Authentication
       include LinkedData::Models::Users::OAuthAuthentication
+      include LinkedData::Concerns::Analytics
+
+      ANALYTICS_REDIS_FIELD = "user_analytics"
+      PAGES_ANALYTICS_REDIS_FIELD = "pages_analytics"
 
       attr_accessor :show_apikey
 
@@ -107,6 +111,13 @@ module LinkedData
         else
           self.username.to_s
         end
+      end
+      def self.analytics_redis_key
+        ANALYTICS_REDIS_FIELD
+      end
+
+      def self.page_visits_analytics
+        load_data(PAGES_ANALYTICS_REDIS_FIELD)
       end
 
       private

--- a/test/models/test_analytics.rb
+++ b/test/models/test_analytics.rb
@@ -1,0 +1,95 @@
+require_relative "../test_case"
+
+class LinkedData::Models::User
+  @@user_analytics = {}
+
+  def self.update_class_variable(new_value)
+    @@user_analytics = new_value
+  end
+  def self.load_data(field_name)
+    @@user_analytics
+  end
+end
+
+class LinkedData::Models::Ontology
+  def self.load_analytics_data
+    ontologies_analytics = {}
+    acronyms = %w[E-PHY AGROVOC TEST]
+    acronyms.each do |acronym|
+      ontologies_analytics[acronym] = {
+        "2021" => (1..12).map { |i| [i.to_s, i * 2021] }.to_h,
+        "2022" => (1..12).map { |i| [i.to_s, i * 2022] }.to_h,
+        "2023" => (1..12).map { |i| [i.to_s, i * 2023] }.to_h,
+      }
+    end
+    ontologies_analytics
+  end
+end
+
+class TestAnalytics < LinkedData::TestCase
+
+  def test_ontologies_analytics
+    ontologies_analytics =  LinkedData::Models::Ontology.load_analytics_data
+    analytics = LinkedData::Models::Ontology.analytics
+    assert_equal ontologies_analytics, analytics
+
+
+    month_analytics = LinkedData::Models::Ontology.analytics(2023, 1)
+    refute_empty month_analytics
+    month_analytics.each do |_, month_analytic|
+      exp = { "2023" => { "1" => 2023 } }
+      assert_equal exp, month_analytic
+    end
+
+    analytics = LinkedData::Models::Ontology.analytics(nil, nil, 'TEST')
+    exp = { "TEST" => ontologies_analytics["TEST"] }
+    assert_equal exp, analytics
+
+
+    month_analytics = LinkedData::Models::Ontology.analytics(2021, 2, 'TEST')
+    refute_empty month_analytics
+    month_analytics.each do |_, month_analytic|
+      exp = { "2021" => { "2" => 2 * 2021 } }
+      assert_equal exp, month_analytic
+    end
+  end
+
+  def test_user_analytics
+
+    user_analytics = { 'all_users' => {
+      "2021" => (1..12).map { |i| [i.to_s, i * 2021] }.to_h,
+      "2022" => (1..12).map { |i| [i.to_s, i * 2022] }.to_h,
+      "2023" => (1..12).map { |i| [i.to_s, i * 2023] }.to_h,
+    } }
+    LinkedData::Models::User.update_class_variable(user_analytics)
+
+
+    analytics = LinkedData::Models::User.analytics
+    assert_equal user_analytics, analytics
+
+    month_analytics = LinkedData::Models::User.analytics(2023, 1)
+    refute_empty month_analytics
+    month_analytics.each do |_, month_analytic|
+      exp = { "2023" => { "1" => 2023 } }
+      assert_equal exp, month_analytic
+    end
+  end
+
+  def test_page_visits_analytics
+    user_analytics = { 'all_pages' => { "/annotator" => 229,
+                                          "/mappings" => 253,
+                                          "/login" => 258,
+                                          "/ontologies/CSOPRA" => 273,
+                                          "/admin" => 280,
+                                          "/search" => 416,
+                                          "/" => 4566 }
+    }
+
+    LinkedData::Models::User.update_class_variable(user_analytics)
+
+    analytics = LinkedData::Models::User.page_visits_analytics
+    assert_equal user_analytics, analytics
+
+  end
+
+end


### PR DESCRIPTION
Related to https://github.com/ontoportal-lirmm/ncbo_cron/pull/17 and https://github.com/agroportal/project-management/issues/439

### Changes 

* Add ontologies and user analytics tests (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/7248407c787e4c8652e59ecccb1371463a2b6247) 
* Extract analytics concern to a file that loads and parses google analytics data saved in Redis (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/1a3bc3806451ff792a6c115ce10ca6f769fd471a)
* Add users visits per month and pages visited in the previous month's stats (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/695f2b345b5c04b80148cc9013739e4f86959c17)
