### PR TITLE
Fix: an  issue after update RDF gem to 3.0 that frozen request params

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       retries: 5
 
   agraph-ut:
-    image: franzinc/agraph:v8.0.0.rc1
+    image: franzinc/agraph:v8.1.0
     platform: linux/amd64
     environment:
       - AGRAPH_SUPER_USER=test

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
@@ -276,6 +276,11 @@ module LinkedData
           ontology_domain_list
         end
 
+        def default_sparql_endpoint(sub)
+          url = LinkedData.settings.sparql_endpoint_url || ''
+
+          url.strip.blank? ? [] :  [RDF::URI.new(url)]
+        end
         def open_search_default(sub)
           RDF::URI.new("#{LinkedData.settings.rest_url_prefix}search?ontologies=#{sub.ontology.acronym}&q=")
         end

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -127,7 +127,7 @@ module LinkedData
       attribute :openSearchDescription, namespace: :void, type: :uri, default: -> (s) {open_search_default(s)}
       attribute :source, namespace: :dct, type: :list
       attribute :endpoint, namespace: :sd, type: %i[uri list],
-                           default: ->(s) {[RDF::URI.new(LinkedData.settings.sparql_endpoint_url)]}
+                           default: ->(s) { default_sparql_endpoint(s)}
       attribute :includedInDataCatalog, namespace: :schema, type: %i[list uri]
 
       # Relations


### PR DESCRIPTION
### Changes 

* fix an issue after update RDF gem to 3.0 that frozen request params (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/69d0ea3ae55d443303bd847e1d2de8b670a8dc1c)
* handle the case when the SPARQL endpoint default value is empty (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/603a3806cc333a6b94d22617d8d5a1af979b7766)