### PR TITLE
Revert "Fix: Add default serialization attributes for agents"

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -19,8 +19,6 @@ module LinkedData
       embed :identifiers, :affiliations
       embed_values affiliations: LinkedData::Models::Agent.goo_attrs_to_load + [identifiers: LinkedData::Models::AgentIdentifier.goo_attrs_to_load]
       serialize_methods :usages
-      
-      serialize_default :name, :agentType, :acronym, :email, :homepage, :identifiers
 
       write_access :creator
       access_control_load :creator

--- a/lib/ontologies_linked_data/models/agents/identifier.rb
+++ b/lib/ontologies_linked_data/models/agents/identifier.rb
@@ -13,8 +13,6 @@ module LinkedData
 
       embedded true
 
-      serialize_default  :notation, :schemaAgency
-    
       write_access :creator
       access_control_load :creator
 


### PR DESCRIPTION
Reverts this https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/190 as change a default behavior, that breaks the API tests and UI agents related features.