### PR TITLE
Feat: add created ontologies attribute to user model

### DIFF
--- a/lib/ontologies_linked_data/models/agents/identifier.rb
+++ b/lib/ontologies_linked_data/models/agents/identifier.rb
@@ -47,8 +47,10 @@ module LinkedData
             return [:notation_format, "`notation` must be compliant with ORCID format"]
           end
         when "ISNI"
-          unless notation.match?(/^\d{4}\s?\d{4}\s?\d{4}\s?\d{3}[\dX]$/)
-            return [:notation_format, "`notation` must be compliant with ISNI format"]
+          # 16 digits, last one can be X
+          # spaces optiona between the numbers but the problem is that spaces will not be accepted in sparql query becuase goo change them to \u00          
+          unless notation.match?(/^\d{15}[\dX]$/)
+            return [:notation_format, "`notation` must be 16 digits (last digit may be X) without spaces"]
           end
         when "GRID"
           unless notation.match?(/^grid\.[0-9]+\.[a-f0-9]{1,2}$/i)

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -35,6 +35,7 @@ module LinkedData
       attribute :resetToken
       attribute :resetTokenExpireTime
       attribute :provisionalClasses, inverse: { on: :provisional_class, attribute: :creator }
+      attribute :createdOntologies, enforce: [:list], handler: :load_created_ontologies
 
       # Hypermedia settings
       embed :subscription
@@ -42,6 +43,8 @@ module LinkedData
       serialize_default :username, :email, :role, :apikey
       serialize_never :passwordHash, :show_apikey, :resetToken, :resetTokenExpireTime
       serialize_filter lambda {|inst| show_apikey?(inst)}
+
+      link_to LinkedData::Hypermedia::Link.new("createdOntologies", lambda {|s| "users/#{s.username}/ontologies"}, nil)
 
       # Cache
       cache_timeout 3600
@@ -94,6 +97,22 @@ module LinkedData
         end
 
         super
+      end
+
+      def load_created_ontologies
+        ontologies = []
+        q = Goo.sparql_query_client.select(:id, :acronym, :administeredBy).distinct
+              .from(Ontology.uri_type)
+              .where(
+                [:id, LinkedData::Models::Ontology.attribute_uri(:administeredBy), :administeredBy],
+                [:id, LinkedData::Models::Ontology.attribute_uri(:acronym), :acronym],
+              )
+              .filter("?administeredBy = <#{self.id}>")
+        acronyms = q.execute.map { |o| o.acronym.to_s }
+        return ontologies if acronyms.empty?
+        filter_by_acronym = Goo::Filter.new(:acronym).regex(acronyms.join('|'))
+        ontologies = Ontology.where.include(Ontology.goo_attrs_to_load([:all])).filter(filter_by_acronym).all
+        return ontologies
       end
 
       def admin?

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -44,7 +44,7 @@ module LinkedData
       serialize_never :passwordHash, :show_apikey, :resetToken, :resetTokenExpireTime
       serialize_filter lambda {|inst| show_apikey?(inst)}
 
-      link_to LinkedData::Hypermedia::Link.new("createdOntologies", lambda {|s| "users/#{s.username}/ontologies"}, nil)
+      link_to LinkedData::Hypermedia::Link.new("createdOntologies", lambda {|s| "users/#{s.id.split('/').last}/ontologies"}, nil)
 
       # Cache
       cache_timeout 3600


### PR DESCRIPTION
### Context
See issue:
- https://github.com/agroportal/project-management/issues/762


This will add the ability to load user specific ontologies from the user model