### PR TITLE
Feat: Add sampleQueries to ontology and catalog models

### DIFF
--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
@@ -40,6 +40,7 @@ module LinkedData
             attribute :bugDatabase, namespace: :doap, enforce: [:string]
             attribute :relation, namespace: :dcterms, enforce: [:string]
             attribute :hasPolicy, namespace: :mod, enforce: [:string]
+            attribute :sampleQueries, namespace: :mod, enforce: [:list, :string]
 
             attribute :created, namespace: :dcterms, enforce: [:date]
             attribute :curatedOn, namespace: :pav, enforce: [:date]
@@ -173,7 +174,7 @@ module LinkedData
             serialize_default :acronym, :title, :color, :description, :logo,:identifier, :status, :language, :type, :accessRights, :license, :rightsHolder,
                               :landingPage, :keyword, :bibliographicCitation, :created, :modified , :contactPoint, :creator, :contributor,
                               :publisher, :subject, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, :wasGeneratedBy, :accessURL,
-                              :numberOfArtefacts, :federated_portals, :fundedBy
+                              :numberOfArtefacts, :federated_portals, :fundedBy, :sampleQueries
 
             embed :rightsHolder, :contactPoint, :creator, :contributor, :curatedBy, :translator, :publisher, :endorsedBy
 

--- a/lib/ontologies_linked_data/models/ontology.rb
+++ b/lib/ontologies_linked_data/models/ontology.rb
@@ -48,6 +48,7 @@ module LinkedData
       attribute :flat, enforce: [:boolean]
       attribute :hasDomain, namespace: :omv, enforce: [:list, :category]
       attribute :summaryOnly, enforce: [:boolean]
+      attribute :sampleQueries, namespace: :mod, enforce: [:list, :string]
 
       attribute :acl, enforce: [:list, :user]
 
@@ -56,7 +57,7 @@ module LinkedData
       attribute :ontologyType, enforce: [:ontology_type], default: lambda { |record| LinkedData::Models::OntologyType.find("ONTOLOGY").include(:code).first }
 
       # Hypermedia settings
-      serialize_default :administeredBy, :acronym, :name, :summaryOnly, :flat, :ontologyType, :group, :hasDomain, :viewingRestriction, :viewOf, :views
+      serialize_default :administeredBy, :acronym, :name, :summaryOnly, :flat, :ontologyType, :group, :hasDomain, :viewingRestriction, :viewOf, :views, :sampleQueries
       links_load :acronym
       link_to LinkedData::Hypermedia::Link.new("submissions", lambda {|s| "ontologies/#{s.acronym}/submissions"}, LinkedData::Models::OntologySubmission.uri_type),
               LinkedData::Hypermedia::Link.new("properties", lambda {|s| "ontologies/#{s.acronym}/properties"}, "#{Goo.namespaces[:metadata].to_s}Property"),

--- a/test/models/mod/test_artefact_catalog.rb
+++ b/test/models/mod/test_artefact_catalog.rb
@@ -25,6 +25,7 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
       description: "Welcome to OntoPortal Appliance, your ontology repository for your ontologies",
       status: "alpha",
       accessRights: "public",
+      sampleQueries: ["SELECT * WHERE {\n ?s ?p ?o \n} LIMIT 5"],
       logo: "https://ontoportal.org/images/logo.png",
       license: "https://opensource.org/licenses/BSD-2-Clause",
       federated_portals: [
@@ -56,7 +57,7 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
       default_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([])
       assert_equal [:acronym, :title, :color, :description, :logo, :identifier, :status, :language, :type, :accessRights, :license, :rightsHolder, 
       :landingPage, :keyword, :bibliographicCitation, :created, :modified, :contactPoint, :creator, :contributor, :publisher, :subject,
-      :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, :wasGeneratedBy, :accessURL, :numberOfArtefacts, :federated_portals, :fundedBy].sort, (default_attrs.flat_map { |e| e.is_a?(Hash) ? e.keys : e }).sort
+      :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, :wasGeneratedBy, :accessURL, :numberOfArtefacts, :federated_portals, :fundedBy, :sampleQueries].sort, (default_attrs.flat_map { |e| e.is_a?(Hash) ? e.keys : e }).sort
 
       specified_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:acronym, :title, :keyword, :featureList])
       assert_equal [:acronym, :title, :keyword, :featureList], specified_attrs
@@ -73,5 +74,21 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
     all_attrs_to_bring = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:all])
     sac.bring(*all_attrs_to_bring)
     assert_equal (all_attrs_to_bring.flat_map { |e| e.is_a?(Hash) ? e.keys : e }).sort, (sac.loaded_attributes.to_a + [:type]).sort
+  end
+
+  def test_semantic_artefact_catalog_sample_queries
+    catalog = LinkedData::Models::SemanticArtefactCatalog.new
+    catalog.acronym = "TEST-CAT-SQ"
+    catalog.title = "Test Catalog Sample Queries"
+    queries = ["SELECT * WHERE {\n ?s ?p ?o \n} LIMIT 5"]
+    catalog.sampleQueries = queries
+    assert_equal queries, catalog.sampleQueries
+    if catalog.valid?
+        catalog.save
+        saved_catalog = LinkedData::Models::SemanticArtefactCatalog.find(catalog.id).first
+        saved_catalog.bring(*LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([]))
+        assert_equal queries, saved_catalog.sampleQueries
+        catalog.delete
+    end
   end
 end

--- a/test/models/mod/test_artefact_catalog.rb
+++ b/test/models/mod/test_artefact_catalog.rb
@@ -25,7 +25,7 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
       description: "Welcome to OntoPortal Appliance, your ontology repository for your ontologies",
       status: "alpha",
       accessRights: "public",
-      sampleQueries: ["SELECT * WHERE {\n ?s ?p ?o \n} LIMIT 5"],
+      sampleQueries: [],
       logo: "https://ontoportal.org/images/logo.png",
       license: "https://opensource.org/licenses/BSD-2-Clause",
       federated_portals: [

--- a/test/models/test_ontology.rb
+++ b/test/models/test_ontology.rb
@@ -496,4 +496,29 @@ class TestOntology < LinkedData::TestOntologyCommon
     assert_equal "test 1", otest.name
   end
 
+  def test_ontology_sample_queries
+    user = LinkedData::Models::User.new(username: "test_user_sq", email: "test_sq@example.org")
+    user.passwordHash = "test_password"
+    user.save
+    
+    ontology = LinkedData::Models::Ontology.new
+    ontology.acronym = "TEST-ONT-SQ"
+    ontology.name = "Test Ontology Sample Queries"
+    ontology.administeredBy = [user]
+    queries = [
+      "SELECT * WHERE {\n ?s ?p ?o \n} LIMIT 10",
+      "SELECT ?s \nWHERE { \n?s a owl:Class \n}"
+    ]
+    ontology.sampleQueries = queries
+    
+    assert ontology.valid?
+    ontology.save
+    
+    saved_ontology = LinkedData::Models::Ontology.find(ontology.id).include(:sampleQueries).first
+    assert_equal queries, saved_ontology.sampleQueries
+    
+    ontology.delete
+    user.delete
+  end
+
 end

--- a/test/models/test_ontology.rb
+++ b/test/models/test_ontology.rb
@@ -515,7 +515,7 @@ class TestOntology < LinkedData::TestOntologyCommon
     ontology.save
     
     saved_ontology = LinkedData::Models::Ontology.find(ontology.id).include(:sampleQueries).first
-    assert_equal queries, saved_ontology.sampleQueries
+    assert_equal queries.sort, saved_ontology.sampleQueries.sort
     
     ontology.delete
     user.delete


### PR DESCRIPTION
`sampleQueries` attribute added to:
- ontology model
- SemanticArtefactCatalog model

this will be used in the API and the UI so that the users can add, edit and select their sample queries that will be shown by default.