### PR TITLE
Fix: add models acronym and id validation

### DIFF
--- a/lib/ontologies_linked_data/models/agents/identifier.rb
+++ b/lib/ontologies_linked_data/models/agents/identifier.rb
@@ -6,7 +6,7 @@ module LinkedData
 
       model :Identifier, namespace: :adms, name_with: lambda {  |i| generate_identifier(i.notation, i.schemaAgency)}
 
-      attribute :notation, namespace: :skos, enforce: %i[existence no_url notation_format]
+      attribute :notation, namespace: :skos, enforce: %i[existence no_url validate_notation_format]
       attribute :schemaAgency, namespace: :adms, enforcedValues: IDENTIFIER_SCHEMES.keys, enforce: [:existence]
       attribute :schemeURI, handler: :scheme_uri_infer
       attribute :creator, type: :user, enforce: [:existence]
@@ -31,7 +31,7 @@ module LinkedData
         return  notation&.start_with?('http') ? [:no_url, "`notation` must not be a URL"]  : []
       end
 
-      def notation_format(inst, attr)
+      def validate_notation_format(inst, attr)
         inst.bring([attr, :schemaAgency]) if inst.bring?(attr)
         notation = inst.send(attr)
         schema_agency = inst.send(:schemaAgency)

--- a/lib/ontologies_linked_data/models/category.rb
+++ b/lib/ontologies_linked_data/models/category.rb
@@ -2,7 +2,7 @@ module LinkedData
   module Models
     class Category < LinkedData::Models::Base
       model :category, name_with: :acronym
-      attribute :acronym, enforce: [:unique, :existence]
+      attribute :acronym, enforce: [:unique, :existence, :validate_acronym]
       attribute :name, enforce: [:existence]
       attribute :description
       attribute :created, enforce: [:date_time], default: lambda { |record| DateTime.now }
@@ -11,6 +11,13 @@ module LinkedData
 
       serialize_default :acronym, :name, :description, :created, :parentCategory, :ontologies
       cache_timeout 86400
+
+      def validate_acronym(inst, attr)
+        inst.bring(attr) if inst.bring?(attr)
+        acronym = inst.send(attr)
+        return acronym.match?(/^[A-Z][A-Z0-9_-]*$/) ? [] : [:validate_acronym, "`acronym` must be uppercase letters, numbers, underscores or hyphens only and must start with a letter"]
+      end
+
     end
   end
 end

--- a/lib/ontologies_linked_data/models/category.rb
+++ b/lib/ontologies_linked_data/models/category.rb
@@ -15,7 +15,7 @@ module LinkedData
       def validate_acronym(inst, attr)
         inst.bring(attr) if inst.bring?(attr)
         acronym = inst.send(attr)
-        return acronym.match?(/^[A-Z][A-Z0-9_-]*$/) ? [] : [:validate_acronym, "`acronym` must be uppercase letters, numbers, underscores or hyphens only and must start with a letter"]
+        return acronym&.match?(/^[A-Z][A-Z0-9_-]*$/) ? [] : [:validate_acronym, "`acronym` must be uppercase letters, numbers, underscores or hyphens only and must start with a letter"]
       end
 
     end

--- a/lib/ontologies_linked_data/models/group.rb
+++ b/lib/ontologies_linked_data/models/group.rb
@@ -2,7 +2,7 @@ module LinkedData
   module Models
     class Group < LinkedData::Models::Base
       model :group, name_with: :acronym
-      attribute :acronym, enforce: [:unique, :existence]
+      attribute :acronym, enforce: [:unique, :existence, :validate_acronym]
       attribute :name, enforce: [:existence]
       attribute :description
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
@@ -10,6 +10,12 @@ module LinkedData
 
       serialize_default :acronym, :name, :description, :created, :ontologies
       cache_timeout 86400
+
+      def validate_acronym(inst, attr)
+        inst.bring(attr) if inst.bring?(attr)
+        acronym = inst.send(attr)
+        return acronym&.match?(/^[A-Z][A-Z0-9_-]*$/) ? [] : [:validate_acronym, "`acronym` must be uppercase letters, numbers, underscores or hyphens only and must start with a letter"]
+      end
     end
   end
 end

--- a/lib/ontologies_linked_data/models/project.rb
+++ b/lib/ontologies_linked_data/models/project.rb
@@ -2,7 +2,7 @@ module LinkedData
   module Models
     class Project < LinkedData::Models::Base
       model :project, :name_with => :acronym
-      attribute :acronym, enforce: [:unique, :existence]
+      attribute :acronym, enforce: [:unique, :existence, :validate_acronym]
       attribute :creator, enforce: [:existence, :user, :list]
       attribute :created, enforce: [:date_time], :default => lambda {|x| DateTime.now }
       attribute :updated, enforce: [:date_time], :default => lambda {|x| DateTime.now }
@@ -12,6 +12,12 @@ module LinkedData
       attribute :contacts
       attribute :institution
       attribute :ontologyUsed, enforce: [:ontology, :list]
+
+      def validate_acronym(inst, attr)
+        inst.bring(attr) if inst.bring?(attr)
+        acronym = inst.send(attr)
+        return acronym&.match?(/^[a-zA-Z0-9][a-zA-Z0-9_-]{1,18}[a-zA-Z0-9]$/) ? [] : [:validate_acronym, "`acronym` must be 3-20 characters, start and end with a letter or number, and may include _, or -"]
+      end
     end
   end
 end

--- a/lib/ontologies_linked_data/models/slice.rb
+++ b/lib/ontologies_linked_data/models/slice.rb
@@ -16,7 +16,7 @@ module LinkedData::Models
       value = inst.send(attr)
       acronym_regex = /\A[-_a-z]+\Z/
       if (acronym_regex.match value).nil?
-        return [:acronym_value_validator,"The acronym value #{value} is invalid"]
+        return [:acronym_value_validator,"`acronym` must contains lowercase letters, underscores or hyphens only"]
       end
       return [:acronym_value_validator, nil]
     end

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -19,7 +19,7 @@ module LinkedData
       attr_accessor :show_apikey
 
       model :user, name_with: :username
-      attribute :username, enforce: [:unique, :existence]
+      attribute :username, enforce: [:unique, :existence, :validate_username]
       attribute :email, enforce: [:unique, :existence]
       attribute :role, enforce: [:role, :list], :default => lambda {|x| [LinkedData::Models::Users::Role.default]}
       attribute :firstName
@@ -163,6 +163,12 @@ module LinkedData
 
       def self.page_visits_analytics
         load_data(PAGES_ANALYTICS_REDIS_FIELD)
+      end
+
+      def validate_username(inst, attr)
+        inst.bring(attr) if inst.bring?(attr)
+        username = inst.send(attr)
+        return username&.match?(/^[a-zA-Z0-9][a-zA-Z0-9._-]{3,18}[a-zA-Z0-9]$/) ? [] : [:validate_username, "`username` must be 5-20 characters, start and end with a letter or number, and may include ., _, or -"]
       end
 
       private


### PR DESCRIPTION
Fix for: http://github.com/agroportal/project-management/issues/808

- restrict category acronym to have only `uppercase letters, numbers, underscores or hyphens only` and `must start with a letter`