### PR TITLE
feat: Inject default catalog and SPARQL endpoint during metadata extraction

### DIFF
--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
@@ -26,7 +26,8 @@ module LinkedData
           end
         end
 
-        populate_default_values(logger)
+        populate_default_value(:includedInDataCatalog, LinkedData.settings.rest_url_prefix.to_s, logger)
+        populate_default_value(:endpoint, LinkedData.settings.sparql_endpoint_url.to_s, logger)
 
         if @submission.valid?
           @submission.save
@@ -311,32 +312,20 @@ eos
         before_last_sub.public_send(attr.to_s)
       end
 
-      def populate_default_values(logger)
-        rest_url   = LinkedData.settings.rest_url_prefix.to_s
-        sparql_url = LinkedData.settings.sparql_endpoint_url.to_s
 
-        if !rest_url.empty?
-          default_catalog = RDF::URI.new(rest_url)
-          current_catalog_values = Array(@submission.includedInDataCatalog).map { |v| RDF::URI.new(v.to_s) }
+      # Generic helper: adds +url+ as a default RDF::URI value for the given submission +attr+
+      # (a symbol like :includedInDataCatalog or :endpoint) unless it is already present.
+      def populate_default_value(attr, url, logger)
+        return if url.empty?
 
-          if current_catalog_values.include?(default_catalog)
-            logger.info("Default catalog '#{default_catalog}' already present in includedInDataCatalog. Skipping.")
-          else
-            @submission.includedInDataCatalog = (current_catalog_values + [default_catalog]).uniq
-            logger.info("Default catalog '#{default_catalog}' added to includedInDataCatalog.")
-          end
-        end
+        default_uri     = RDF::URI.new(url)
+        current_values  = Array(@submission.public_send(attr)).map { |v| RDF::URI.new(v.to_s) }
 
-        if !sparql_url.empty?
-          default_endpoint = RDF::URI.new(sparql_url)
-          current_endpoints = Array(@submission.endpoint).map { |v| RDF::URI.new(v.to_s) }
-
-          if current_endpoints.include?(default_endpoint)
-            logger.info("Default endpoint '#{default_endpoint}' already present in endpoint. Skipping.")
-          else
-            @submission.endpoint = (current_endpoints + [default_endpoint]).uniq
-            logger.info("Default endpoint '#{default_endpoint}' added to endpoint.")
-          end
+        if current_values.include?(default_uri)
+          logger.info("Default value '#{default_uri}' already present in #{attr}. Skipping.")
+        else
+          @submission.public_send(:"#{attr}=", (current_values + [default_uri]).uniq)
+          logger.info("Default value '#{default_uri}' added to #{attr}.")
         end
       end
 

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
@@ -26,6 +26,8 @@ module LinkedData
           end
         end
 
+        populate_default_values(logger)
+
         if @submission.valid?
           @submission.save
         else
@@ -307,6 +309,35 @@ eos
         before_last_sub.bring(attr)
 
         before_last_sub.public_send(attr.to_s)
+      end
+
+      def populate_default_values(logger)
+        rest_url   = LinkedData.settings.rest_url_prefix.to_s
+        sparql_url = LinkedData.settings.sparql_endpoint_url.to_s
+
+        if !rest_url.empty?
+          default_catalog = RDF::URI.new(rest_url)
+          current_catalog_values = Array(@submission.includedInDataCatalog).map { |v| RDF::URI.new(v.to_s) }
+
+          if current_catalog_values.include?(default_catalog)
+            logger.info("Default catalog '#{default_catalog}' already present in includedInDataCatalog. Skipping.")
+          else
+            @submission.includedInDataCatalog = (current_catalog_values + [default_catalog]).uniq
+            logger.info("Default catalog '#{default_catalog}' added to includedInDataCatalog.")
+          end
+        end
+
+        if !sparql_url.empty?
+          default_endpoint = RDF::URI.new(sparql_url)
+          current_endpoints = Array(@submission.endpoint).map { |v| RDF::URI.new(v.to_s) }
+
+          if current_endpoints.include?(default_endpoint)
+            logger.info("Default endpoint '#{default_endpoint}' already present in endpoint. Skipping.")
+          else
+            @submission.endpoint = (current_endpoints + [default_endpoint]).uniq
+            logger.info("Default endpoint '#{default_endpoint}' added to endpoint.")
+          end
+        end
       end
 
 

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_extract_metadata.rb
@@ -313,8 +313,6 @@ eos
       end
 
 
-      # Generic helper: adds +url+ as a default RDF::URI value for the given submission +attr+
-      # (a symbol like :includedInDataCatalog or :endpoint) unless it is already present.
       def populate_default_value(attr, url, logger)
         return if url.empty?
 

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -60,7 +60,11 @@ class TestArtefact < LinkedData::TestOntologyCommon
 
                 if value_submission_attr.is_a?(Array)
                     value_artefact_attr.each_with_index do |v, i|
-                        assert_equal v.id, value_submission_attr[i].id
+                        if v.respond_to?(:id) && value_submission_attr[i].respond_to?(:id)
+                            assert_equal v.id, value_submission_attr[i].id
+                        else
+                            assert_equal v, value_submission_attr[i]
+                        end
                     end
                 else
                     assert_equal value_artefact_attr, value_submission_attr


### PR DESCRIPTION
Adds populate_default_values in SubmissionExtractMetadata to automatically inject portal-wide defaults into each submission:

includedInDataCatalog ← LinkedData.settings.rest_url_prefix
endpoint ← LinkedData.settings.sparql_endpoint_url
Both are idempotent (skipped if already set) and read from config (no hardcoded URLs).

Also fixes test_artefact.rb to handle RDF::URI values that don't respond to .id

<img width="1586" height="1091" alt="image" src="https://github.com/user-attachments/assets/65f9934b-e891-4566-bd88-5d4d84efcdba" />
