### PR TITLE
feat: add links.ui to Project and Agent models (related issue #176)

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -21,7 +21,10 @@ module LinkedData
       embed_values affiliations: [:name, :agentType, :homepage, :acronym, :email, :identifiers]
 
       prevent_serialize_when_nested :usages, :affiliations, :keywords, :groups, :categories, :subjects, :relatedAgents, :affiliatedAgents
-          
+
+      # Hypermedia links
+      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |a| "http://#{LinkedData.settings.ui_host}/agents/#{a.id.to_s.split('/').last}" }, self.uri_type)
+
       write_access :creator
       access_control_load :creator
 

--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -23,7 +23,7 @@ module LinkedData
       prevent_serialize_when_nested :usages, :affiliations, :keywords, :groups, :categories, :subjects, :relatedAgents, :affiliatedAgents
 
       # Hypermedia links
-      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |a| "http://#{LinkedData.settings.ui_host}/agents/#{a.id.to_s.split('/').last}" }, self.uri_type)
+      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |a| "https://#{LinkedData.settings.ui_host}/agents/#{a.id.to_s.split('/').last}" }, self.uri_type)
 
       write_access :creator
       access_control_load :creator

--- a/lib/ontologies_linked_data/models/ontology.rb
+++ b/lib/ontologies_linked_data/models/ontology.rb
@@ -80,7 +80,7 @@ module LinkedData
               LinkedData::Hypermedia::Link.new("analytics", lambda {|s| "ontologies/#{s.acronym}/analytics"}, "#{Goo.namespaces[:metadata].to_s}Analytics"),
               LinkedData::Hypermedia::Link.new("agents", lambda {|s| "ontologies/#{s.acronym}/agents"}, LinkedData::Models::Agent.uri_type),
               LinkedData::Hypermedia::Link.new("mappings", lambda {|s| "ontologies/#{s.acronym}/mappings"}, LinkedData::Models::Mapping.type_uri),
-              LinkedData::Hypermedia::Link.new("ui", lambda {|s| "http://#{LinkedData.settings.ui_host}/ontologies/#{s.acronym}"}, self.uri_type)
+              LinkedData::Hypermedia::Link.new("ui", lambda {|s| "https://#{LinkedData.settings.ui_host}/ontologies/#{s.acronym}"}, self.uri_type)
 
       # Access control
       read_restriction lambda {|o| !o.viewingRestriction.eql?("public") }

--- a/lib/ontologies_linked_data/models/project.rb
+++ b/lib/ontologies_linked_data/models/project.rb
@@ -12,9 +12,7 @@ module LinkedData
       attribute :contacts
       attribute :institution
       attribute :ontologyUsed, enforce: [:ontology, :list]
-
-      links_load :acronym
-      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |p| "http://#{LinkedData.settings.ui_host}/projects/#{p.acronym}" }, self.uri_type)
+      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |p| "https://#{LinkedData.settings.ui_host}/projects/#{p.acronym}" }, self.uri_type)
     end
   end
 end

--- a/lib/ontologies_linked_data/models/project.rb
+++ b/lib/ontologies_linked_data/models/project.rb
@@ -12,7 +12,9 @@ module LinkedData
       attribute :contacts
       attribute :institution
       attribute :ontologyUsed, enforce: [:ontology, :list]
+
+      links_load :acronym
+      link_to LinkedData::Hypermedia::Link.new("ui", lambda { |p| "http://#{LinkedData.settings.ui_host}/projects/#{p.acronym}" }, self.uri_type)
     end
   end
 end
-


### PR DESCRIPTION
Add hypermedia 'ui' link to Project and Agent meta_data, pointing to the corresponding portal page.

- Project: http://<ui_host>/projects/<acronym>
- Agent:   http://<ui_host>/agents/<uuid>

Follows the same pattern already used by the Ontology model. Resolves [#176](https://github.com/agroportal/ontologies_api/issues/176)

[demo2.webm](https://github.com/user-attachments/assets/d49e1e9a-9cd2-4233-a12b-142b47f1db9c)
