### PR TITLE
Feat: add creation date attribute to Agent model

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -16,6 +16,7 @@ module LinkedData
       attribute :identifiers, namespace: :adms, property: :identifier, enforce: %i[Identifier list unique_identifiers], fuzzy_search: true
       attribute :affiliations, enforce: %i[Agent list is_organization], namespace: :org, property: :memberOf
       attribute :creator, type: :user, enforce: [:existence]
+      attribute :created, namespace: :dcterms, enforce: [:date_time], default: lambda { |record| DateTime.now }
       embed :identifiers, :affiliations
       serialize_methods :usages, :keywords, :groups, :categories, :subjects, :relatedAgents, :affiliatedAgents
       embed_values affiliations: [:name, :agentType, :homepage, :acronym, :email, :identifiers]


### PR DESCRIPTION
Added creation date (dcterms:created) to the agents model so that it can be used in the statistics page (https://github.com/agroportal/project-management/issues/804).