### PR TITLE
fix: bump agraph image to v8.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
 
 
   agraph-ut:
-    image: franzinc/agraph:v8.1.0
+    image: franzinc/agraph:v8.1.1
     platform: linux/amd64
     environment:
       - AGRAPH_SUPER_USER=test


### PR DESCRIPTION
The v8.1.0 tag was removed from Docker Hub, causing CI to fail with "manifest unknown" when pulling the agraph-ut container.
<img width="994" height="299" alt="Screenshot 2026-05-06 at 07 04 01" src="https://github.com/user-attachments/assets/b2f9cf80-fed7-4629-82e2-ca3f2746139c" />
