### PR TITLE
fix: detect gzip/zip archives on Ubuntu 22 (modern mime types)

### DIFF
--- a/lib/ontologies_linked_data/utils/file.rb
+++ b/lib/ontologies_linked_data/utils/file.rb
@@ -16,20 +16,22 @@ module LinkedData
       end
 
 
-      def self.zip?(file_path)
-        file_path = file_path.to_s
-        raise ArgumentError, "File path #{file_path} not found" unless File.exist? file_path
+      ZIP_MIME_TYPES = %w[application/zip application/x-zip-compressed].freeze
+      GZIP_MIME_TYPES = %w[application/gzip application/x-gzip].freeze
 
-        file_type = `file --mime -b #{Shellwords.escape(file_path)}`
-        file_type.split(';')[0] == 'application/zip'
+      def self.zip?(file_path)
+        ZIP_MIME_TYPES.include?(file_mime_type(file_path))
       end
 
       def self.gzip?(file_path)
+        GZIP_MIME_TYPES.include?(file_mime_type(file_path))
+      end
+
+      def self.file_mime_type(file_path)
         file_path = file_path.to_s
         raise ArgumentError, "File path #{file_path} not found" unless File.exist? file_path
 
-        file_type = `file --mime -b #{Shellwords.escape(file_path)}`
-        file_type.split(';')[0] == 'application/x-gzip'
+        `file --mime -b #{Shellwords.escape(file_path)}`.split(';')[0].strip
       end
 
       def self.files_from_zip(file_path)


### PR DESCRIPTION
## Summary

After migrating our servers from CentOS to Ubuntu 22, ontology submissions distributed as gzip or zip archives stopped being extracted before parsing. The OWLAPI wrapper then received the archive path as its input repository and failed with:

```
o.s.n.o.w.OntologyParserCommand - INPUT_REPO_NOT_A_FOLDER
```
- **CentOs**
```
[ontoportal@agroportal ~]$ file --mime -b /srv/ontoportal/data/repository/GEMET/14/gemet.rdf.gz
application/x-gzip; charset=binary
```
- **Ubuntu**
```
ontoportal@localhost:$ file --mime -b /srv/ontoportal/data/repository/GEMET/14/gemet.rdf.gz
application/gzip; charset=binary
```
Root cause: `LinkedData::Utils::FileHelpers.gzip?` / `zip?` rely on `file --mime -b` and only matched the legacy strings `application/x-gzip` and `application/zip`. On Ubuntu 22 the `file` utility returns the modern equivalents `application/gzip` and (in some cases) `application/x-zip-compressed`, so the detection returns `false`, and the raw archive is handed to OWLAPI.

This patch accepts both the legacy and modern mime strings, restoring archive detection on the new servers.

Affected ontologies observed in production: **GEMET**, **AGROVOC**, **BAGO** 

Stanford already fixed the same issue in [ncbo/ontologies_linked_data@3ccc9d9](https://github.com/ncbo/ontologies_linked_data/commit/3ccc9d979f1d38517b49198dc161baf46285d210)
