### PR TITLE
feat: expose reified skos:definition node content through the API

### DIFF
--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -198,6 +198,7 @@ module LinkedData
       conf.add_namespace(:cclicense, RDF::Vocabulary.new("http://creativecommons.org/licenses/"))
       conf.add_namespace(:nkos, RDF::Vocabulary.new("http://w3id.org/nkos#"))
       conf.add_namespace(:skosxl, RDF::Vocabulary.new("http://www.w3.org/2008/05/skos-xl#"))
+      conf.add_namespace(:vocbench, RDF::Vocabulary.new("http://art.uniroma2.it/ontologies/vocbench#"))
       conf.add_namespace(:dcterms, RDF::Vocabulary.new("http://purl.org/dc/terms/"))
       conf.add_namespace(:uneskos, RDF::Vocabulary.new("http://purl.org/umu/uneskos#"))
 

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -92,12 +92,12 @@ module LinkedData
       # Hypermedia settings
       embed :children, :ancestors, :descendants, :parents, :prefLabelXl, :altLabelXl, :hiddenLabelXl
       serialize_default :prefLabel, :synonym, :definition, :cui, :semanticType, :obsolete, :matchType, :ontologyType, :provisional, :created, :modified, :memberOf, :inScheme # an attribute used in Search (not shown out of context)
-      serialize_methods :properties, :childrenCount, :hasChildren
+      serialize_methods :properties, :childrenCount, :hasChildren, :definitionXl
       serialize_never :submissionAcronym, :submissionId, :submission, :descendants
       aggregates childrenCount: [:count, :children]
       links_load submission: [ontology: [:acronym]]
       do_not_load :descendants, :ancestors
-      prevent_serialize_when_nested :properties, :parents, :children, :ancestors, :descendants, :memberOf
+      prevent_serialize_when_nested :properties, :parents, :children, :ancestors, :descendants, :memberOf, :definitionXl
       link_to LinkedData::Hypermedia::Link.new("self", lambda {|s| "ontologies/#{s.submission.ontology.acronym}/classes/#{CGI.escape(s.id.to_s)}"}, self.uri_type),
               LinkedData::Hypermedia::Link.new("ontology", lambda {|s| "ontologies/#{s.submission.ontology.acronym}"}, Goo.vocabulary["Ontology"]),
               LinkedData::Hypermedia::Link.new("children", lambda {|s| "ontologies/#{s.submission.ontology.acronym}/classes/#{CGI.escape(s.id.to_s)}/children"}, self.uri_type),
@@ -384,6 +384,20 @@ module LinkedData
         properties = self.unmapped(*args)
         BLACKLIST_URIS.each {|bad_iri| properties.delete(RDF::URI.new(bad_iri))}
         properties
+      end
+
+      # Expose the content of reified skos:definition nodes (text + provenance).
+      # `definition` (the flat attribute) is unchanged: for reified definitions
+      # its entries are the bare node URIs; this method resolves those URIs into
+      # structured objects. Plain-literal definitions have no URI entries, so
+      # this returns an empty array and the flat `definition` still carries them.
+      def definitionXl
+        self.bring(:definition) if self.bring?(:definition)
+        uris = Array(self.definition).select { |d| d.is_a?(RDF::URI) }
+        return [] if uris.empty?
+
+        self.bring(:submission) if self.bring?(:submission)
+        LinkedData::Models::SKOS::Definition.reified(uris, self.submission)
       end
 
       def self.partially_load_children(models, threshold, submission)

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -3,6 +3,7 @@ require 'ontologies_linked_data/models/mod/semantic_artefact_catalog_record'
 require 'ontologies_linked_data/models/skos/scheme'
 require 'ontologies_linked_data/models/skos/collection'
 require 'ontologies_linked_data/models/skos/skosxl'
+require 'ontologies_linked_data/models/skos/definition'
 
 
 module LinkedData

--- a/lib/ontologies_linked_data/models/ontology.rb
+++ b/lib/ontologies_linked_data/models/ontology.rb
@@ -9,6 +9,7 @@ require 'ontologies_linked_data/models/project'
 require 'ontologies_linked_data/models/skos/scheme'
 require 'ontologies_linked_data/models/skos/collection'
 require 'ontologies_linked_data/models/skos/skosxl'
+require 'ontologies_linked_data/models/skos/definition'
 require 'ontologies_linked_data/models/notes/note'
 require 'ontologies_linked_data/purl/purl_client'
 

--- a/lib/ontologies_linked_data/models/skos/definition.rb
+++ b/lib/ontologies_linked_data/models/skos/definition.rb
@@ -1,0 +1,171 @@
+module LinkedData
+  module Models
+    module SKOS
+      # Reified SKOS definition node.
+      #
+      # Some ontologies (e.g. AGROVOC, INRAE Thesaurus) do not attach the
+      # definition as a plain literal on `skos:definition`, but reify it onto a
+      # dedicated node whose object carries the definition text plus provenance
+      # (source, dates). The API used to return only the bare node URIs.
+      #
+      # Predicates observed in AgroPortal:
+      #   text    -> rdf:value                     (language tagged)
+      #   source  -> dcterms:source                (INRAE Thesaurus)
+      #           -> vocbench:hasSource            (AGROVOC)
+      #   created -> dcterms:created               (xsd:dateTime, when present)
+      #   modified-> dcterms:modified              (when present)
+      #
+      # IMPORTANT: these reified nodes are NOT reliably typed. AGROVOC nodes have
+      # no rdf:type at all, INRAE nodes are typed rdfs:Resource / owl:NamedIndividual
+      # — never skos:Definition. A normal Goo model query constrains the subject
+      # with `?id a <rdf_type>`, which would exclude every one of these nodes and
+      # return empty objects. We therefore never load these nodes through the
+      # standard typed query path: `Class#definitionXl` calls `reified` below,
+      # which reads the node's predicates directly (no type constraint) and
+      # returns plain, faithfully-built hashes. Nothing is synthesized: a field
+      # appears only when the corresponding triple exists on the node, and any
+      # predicate we do not name explicitly is preserved under `properties`.
+      class Definition < LinkedData::Models::Base
+
+        model :definition, name_with: :id, collection: :submission,
+                           namespace: :skos,
+                           rdf_type: ->(*x) { RDF::URI.new('http://www.w3.org/2004/02/skos/core#Definition') }
+
+        attribute :value, namespace: :rdf
+        attribute :source, namespace: :dcterms
+        attribute :hasSource, namespace: :vocbench, property: :hasSource
+        attribute :created, namespace: :dcterms
+        attribute :modified, namespace: :dcterms
+        attribute :submission, collection: ->(s) { s.resource_id }, namespace: :metadata
+
+        serialize_never :submission, :id
+
+        # RDF predicate -> serialized field name for the reified definition node.
+        PREDICATE_MAP = {
+          'http://www.w3.org/1999/02/22-rdf-syntax-ns#value' => 'value',
+          'http://purl.org/dc/terms/source' => 'source',
+          'http://art.uniroma2.it/ontologies/vocbench#hasSource' => 'hasSource',
+          'http://purl.org/dc/terms/created' => 'created',
+          'http://purl.org/dc/terms/modified' => 'modified'
+        }.freeze
+
+        # Resolve reified definition nodes (given by their URIs) into structured
+        # objects, reading their predicates directly from the submission graph
+        # without any rdf:type constraint. Returns an array of hashes in the same
+        # order as `uris`; nodes with no triples are skipped.
+        #
+        # Language handling mirrors the rest of the API (Goo's language filter):
+        # `requested_lang` comes from the request (`?lang=`/`?language=`), falls
+        # back to the portal language, and `ALL` keeps every language. A node
+        # whose definition text (rdf:value) is in a language other than the
+        # requested one is dropped, so `?lang=fr` returns only the French
+        # definitions; untagged text always matches.
+        def self.reified(uris, submission, requested_lang: RequestStore.store[:requested_lang])
+          uris = Array(uris).map { |u| RDF::URI.new(u.to_s) }
+          return [] if uris.empty? || submission.nil?
+
+          graph = submission.id
+          values = uris.map { |u| "<#{u}>" }.join(' ')
+          query = <<-SPARQL.strip
+SELECT ?def ?p ?o WHERE {
+  GRAPH <#{graph}> {
+    VALUES ?def { #{values} }
+    ?def ?p ?o .
+  }
+}
+          SPARQL
+
+          grouped = Hash.new { |h, k| h[k] = [] }
+          Goo.sparql_query_client.query(query, query_options: { rules: :NONE }, graphs: [graph]).each do |sol|
+            grouped[sol[:def].to_s] << [sol[:p].to_s, sol[:o]]
+          end
+
+          langs = requested_languages(requested_lang)
+          uris.map { |uri| build(uri, grouped[uri.to_s], langs) }.compact
+        end
+
+        # Build one faithful hash from a node's (predicate, object) pairs, keeping
+        # only the definition text that matches the requested language(s).
+        def self.build(uri, predicates, langs = :ALL)
+          return nil if predicates.nil? || predicates.empty?
+
+          obj = { '@id' => uri.to_s, '@type' => type_uri.to_s }
+          properties = Hash.new { |h, k| h[k] = [] }
+          text_by_lang = {}
+
+          predicates.each do |predicate, object|
+            field = PREDICATE_MAP[predicate]
+            case field
+            when 'value'
+              text_by_lang[object_language(object)] = literal_value(object)
+            when nil
+              properties[predicate] << object.to_s
+            else
+              # provenance (source / dates) - not language filtered
+              obj[field] = literal_value(object)
+            end
+          end
+
+          unless text_by_lang.empty?
+            selected = select_language(text_by_lang, langs)
+            return nil if selected.nil? # no text in the requested language
+
+            if selected.is_a?(Hash) # one node carrying several languages (ALL)
+              obj['value'] = selected
+            else
+              language, text = selected
+              obj['value'] = text
+              # Expose the language of this definition's text (like prefLabel's
+              # per-language keys), so consumers can tell them apart under lang=all.
+              obj['lang'] = language.to_s.downcase unless language == :none
+            end
+          end
+
+          obj['properties'] = properties unless properties.empty?
+          obj
+        end
+
+        def self.literal_value(object)
+          object.is_a?(RDF::Literal) ? object.object : object.to_s
+        end
+
+        def self.object_language(object)
+          return :none unless object.is_a?(RDF::Literal) && object.language
+
+          object.language.to_s.upcase.to_sym
+        end
+
+        # Normalize the requested language into :ALL, or an array of upper-cased
+        # language symbols (defaulting to the portal language). Mirrors Goo.
+        def self.requested_languages(requested_lang)
+          return :ALL if requested_lang.to_s.upcase == 'ALL'
+
+          langs = requested_lang
+          langs = Goo.portal_language if langs.nil? || (langs.respond_to?(:empty?) && langs.empty?)
+          langs = langs.to_s.split(',') unless langs.is_a?(Array)
+          langs.map { |l| l.to_s.upcase.to_sym }
+        end
+
+        # Pick the definition text for the requested language(s) from a
+        # {language => text} map. Untagged text (:none) matches any request.
+        # Returns a [language, text] pair, or (for a single node holding several
+        # languages under lang=ALL) a {language => text} Hash, or nil when the
+        # node has no text in the requested language.
+        def self.select_language(text_by_lang, langs)
+          if langs == :ALL
+            return text_by_lang.first if text_by_lang.size == 1
+
+            return text_by_lang.transform_keys { |l| l == :none ? '@none' : l.to_s.downcase }
+          end
+
+          match = text_by_lang.find { |lang, _| lang != :none && langs.include?(lang) }
+          return match if match
+
+          text_by_lang.key?(:none) ? [:none, text_by_lang[:none]] : nil
+        end
+
+      end
+    end
+  end
+
+end

--- a/test/models/skos/test_skos_definition.rb
+++ b/test/models/skos/test_skos_definition.rb
@@ -1,0 +1,158 @@
+require_relative '../test_ontology_common'
+require 'logger'
+
+# Tests for reified skos:definition nodes exposed through Class#definitionXl.
+#
+# The INRAE Thesaurus fixture already contains a reified definition:
+#   c_01cd9294 --skos:definition--> note_a8fb2e24
+# where note_a8fb2e24 carries:
+#   rdf:value    (fr text)
+#   dct:source   (provenance, no date present)
+#   rdf:type rdfs:Resource
+# i.e. text + source but no created/modified date, which exercises the
+# "expose only what is in the RDF" requirement. The node is NOT typed
+# skos:Definition, so it is resolved with a type-free query, not a standard
+# Goo model load.
+class TestSkosDefinition < LinkedData::TestOntologyCommon
+
+  REIFIED_CONCEPT = 'http://opendata.inrae.fr/thesaurusINRAE/c_01cd9294'
+  REIFIED_NODE    = 'http://opendata.inrae.fr/thesaurusINRAE/note_a8fb2e24'
+  EXPECTED_TEXT_START = "Pratique qui se définit comme l'ensemble des processus"
+  EXPECTED_SOURCE_START = "Dérivée de J. Boiffin"
+  RDF_VALUE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value'
+  DCT_SOURCE = 'http://purl.org/dc/terms/source'
+  RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+  RDFS_RESOURCE = 'http://www.w3.org/2000/01/rdf-schema#Resource'
+
+  def self.before_suite
+    LinkedData::TestCase.backend_4s_delete
+    self.new('').submission_parse('INRAETHES', 'Testing skos',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
+                     1,
+                     process_rdf: true, extract_metadata: false, generate_missing_labels: false)
+  end
+
+  def submission
+    LinkedData::Models::Ontology.find('INRAETHES').first.latest_submission
+  end
+
+  # Backend-free: the predicate->field mapping is faithful and never synthesizes
+  # missing provenance. A node with text + source but no dates must NOT produce
+  # created/modified keys, and unmapped predicates land under `properties`.
+  def test_build_maps_predicates_faithfully
+    obj = LinkedData::Models::SKOS::Definition.build(
+      RDF::URI.new(REIFIED_NODE),
+      [
+        [RDF_VALUE, RDF::Literal.new('Pratique qui se définit...', language: :fr)],
+        [DCT_SOURCE, RDF::Literal.new('Dérivée de J. Boiffin...')],
+        [RDF_TYPE, RDF::URI.new(RDFS_RESOURCE)]
+      ]
+    )
+
+    assert_equal REIFIED_NODE, obj['@id']
+    assert_equal 'http://www.w3.org/2004/02/skos/core#Definition', obj['@type']
+    assert obj['value'].to_s.start_with?('Pratique')
+    assert obj['source'].to_s.start_with?('Dérivée')
+    refute obj.key?('created'), 'must not synthesize a created date'
+    refute obj.key?('modified'), 'must not synthesize a modified date'
+    refute obj.key?('hasSource'), 'must not synthesize a vocbench source'
+    assert_equal [RDFS_RESOURCE], obj['properties'][RDF_TYPE]
+  end
+
+  # Backend-free: language selection mirrors the rest of the API. A specific
+  # language keeps only matching (and untagged) definition text and drops nodes
+  # in other languages; ALL keeps everything; untagged text always matches.
+  def test_language_filtering
+    d = LinkedData::Models::SKOS::Definition
+    node = ->(lang) { [[RDF_VALUE, RDF::Literal.new("txt-#{lang}", language: lang)]] }
+
+    fr = d.build(RDF::URI.new('http://x/fr'), node.call(:fr), d.requested_languages('fr'))
+    assert_equal 'txt-fr', fr['value']
+    assert_equal 'fr', fr['lang'], 'each definition exposes the language of its text'
+    assert_nil d.build(RDF::URI.new('http://x/en'), node.call(:en), d.requested_languages('fr')),
+               'a node whose text is in another language must be dropped'
+
+    all = d.build(RDF::URI.new('http://x/fr'), node.call(:fr), d.requested_languages('ALL'))
+    assert_equal 'txt-fr', all['value']
+    assert_equal 'fr', all['lang']
+
+    multi = [[RDF_VALUE, RDF::Literal.new('EN', language: :en)],
+             [RDF_VALUE, RDF::Literal.new('FR', language: :fr)]]
+    assert_equal 'FR', d.build(RDF::URI.new('http://x/m'), multi, d.requested_languages('fr'))['value']
+    assert_equal({ 'en' => 'EN', 'fr' => 'FR' },
+                 d.build(RDF::URI.new('http://x/m'), multi, d.requested_languages('ALL'))['value'])
+
+    # untagged text matches any requested language and carries no lang key
+    untagged = d.build(RDF::URI.new('http://x/u'), [[RDF_VALUE, RDF::Literal.new('plain')]],
+                       d.requested_languages('fr'))
+    assert_equal 'plain', untagged['value']
+    refute untagged.key?('lang')
+  end
+
+  # A concept whose skos:definition object is a resource gets the node resolved
+  # into a structured object, while the flat `definition` attribute is unchanged.
+  def test_class_reified_definition_resolved
+    cls = LinkedData::Models::Class.find(REIFIED_CONCEPT)
+                                   .in(submission)
+                                   .include(:prefLabel, :definition)
+                                   .first
+    refute_nil cls
+
+    # Back-compat: the flat attribute still exposes the raw skos:definition
+    # object (here the bare reified node URI).
+    assert_equal [REIFIED_NODE], cls.definition.map(&:to_s)
+
+    # The node's text is French; request it (default portal language would
+    # filter it out, mirroring the rest of the API).
+    RequestStore.store[:requested_lang] = :FR
+    defs = cls.definitionXl
+    assert_equal 1, defs.size
+    definition = defs.first
+    assert_equal REIFIED_NODE, definition['@id']
+    assert definition['value'].to_s.start_with?(EXPECTED_TEXT_START)
+    assert definition['source'].to_s.start_with?(EXPECTED_SOURCE_START)
+    # Faithful: this node has a source but no date in the RDF.
+    refute definition.key?('created')
+    refute definition.key?('modified')
+  ensure
+    RequestStore.store[:requested_lang] = nil
+  end
+
+  # Back-compat: a concept whose skos:definition object is a plain literal keeps
+  # `definition` as strings, and definitionXl is empty (no reified nodes).
+  def test_class_literal_definition_back_compat
+    literal_concept = find_class_with_literal_definition
+    skip 'No class with a plain-literal definition in fixture' if literal_concept.nil?
+
+    cls = LinkedData::Models::Class.find(literal_concept.to_s)
+                                   .in(submission)
+                                   .include(:definition)
+                                   .first
+    refute_nil cls
+
+    refute_empty cls.definition
+    cls.definition.each { |d| refute d.is_a?(RDF::URI), 'literal definition must not be a URI' }
+    assert_empty cls.definitionXl
+  end
+
+  private
+
+  # Find any loaded class whose skos:definition is a plain literal (object is
+  # not a resource) so we can assert the literal path is unchanged.
+  def find_class_with_literal_definition
+    sub = submission
+    query = <<~SPARQL
+      SELECT DISTINCT ?id WHERE {
+        GRAPH <#{sub.id}> {
+          ?id <http://www.w3.org/2004/02/skos/core#definition> ?def .
+          ?id a <http://www.w3.org/2004/02/skos/core#Concept> .
+          FILTER(isLiteral(?def))
+        }
+      } LIMIT 1
+    SPARQL
+    Goo.sparql_query_client.query(query).each do |sol|
+      return sol[:id]
+    end
+    nil
+  end
+end


### PR DESCRIPTION
## Summary

Exposes the content of **reified `skos:definition` nodes** through the class API. Some ontologies attach a definition as a URI node (carrying the text + provenance) instead of a plain literal; the API previously returned only the bare node URI. This adds a `definitionXl` field on classes that resolves those nodes into structured objects, while leaving the flat `definition` attribute untouched.

## Predicates 

| Field | Predicate |
|---|---|
| text | `rdf:value` (language-tagged) |
| source | `dcterms:source` (INRAE) / `vocbench:hasSource` (AGROVOC) |
| created / modified | `dcterms:created` / `dcterms:modified` (when present) |

## Why a custom resolver instead of a normal model/embed

The reified nodes are **not reliably typed** : AGROVOC nodes have no `rdf:type`, INRAE nodes are `rdfs:Resource`/`owl:NamedIndividual`, never `skos:Definition`. A standard Goo query constrains the subject with `?id a <rdf_type>`, which excludes these nodes and yields all-null objects (this is exactly what a typed embed produced). So `SKOS::Definition.reified` queries the node predicates **directly in the submission graph with no type constraint** and builds the objects itself.

## How it works

- `Class#definitionXl` is a **serialize method** (no controller change needed — serialization is model-driven). It takes the URI-valued entries of the flat `definition`, and calls `SKOS::Definition.reified`.
- Returns an **array of objects**, one per reified node, each with `@id`, `@type`, mapped fields, and a `lang` tag for the text:

```json
"definitionXl": [
  { "@id": ".../note_101800en", "@type": "…#Definition",
    "source": "Adapté de : Baize…", "created": "2026-02-04T…",
    "value": "The action of reducing…", "lang": "en",
    "properties": { "…#type": ["…#NamedIndividual","…#Resource"] } }
]
```

## Back-compat

The flat `definition` attribute is unchanged (literals stay strings, reified entries stay bare URIs). Plain-literal ontologies yield an empty `definitionXl`.