### PR TITLE
feat: add handling for reified definitions

### DIFF
--- a/lib/ontologies_linked_data/models/concerns/submission_process.rb
+++ b/lib/ontologies_linked_data/models/concerns/submission_process.rb
@@ -14,6 +14,10 @@ module LinkedData
         LinkedData::Services::ObsoleteClassesGenerator.new(self).process(logger, file_path: self.master_file_path)
       end
 
+      def resolve_reified_definitions(logger)
+        LinkedData::Services::ResolveReifiedDefinitions.new(self).process(logger, file_path: self.master_file_path)
+      end
+
       def extract_metadata(logger, options = {})
         LinkedData::Services::SubmissionMetadataExtractor.new(self).process(logger, options)
       end

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_reified_definitions.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_reified_definitions.rb
@@ -1,0 +1,328 @@
+require 'benchmark'
+require 'set'
+
+module LinkedData
+  module Services
+
+    # Materialize the text carried by reified definition nodes as plain
+    # skos:definition literals on the concept itself.
+    #
+    # Thesauri such as AGROVOC or the INRAE Thesaurus do not attach the
+    # definition as a literal, they reify it onto a dedicated node:
+    #
+    #   <c_01cd9294>    skos:definition <note_a8fb2e24> .
+    #   <note_a8fb2e24> rdf:value       "Pratique qui se definit..."@fr ;
+    #                   dcterms:source  "Derivee de J. Boiffin..." .
+    #
+    # The definition then reaches the portal as a bare URI: nothing to display,
+    # nothing to index, nothing to annotate. This step follows those nodes,
+    # picks the predicate holding the text with a ranked list of heuristics
+    # (rdf:value, skosxl:literalForm, ... down to skos:prefLabel/rdfs:label) and
+    # asserts the text back on the concept as a skos:definition literal, keeping
+    # the language tag.
+    #
+    # Nothing is removed: like every other step of the pipeline this one only
+    # appends, so the submission graph stays a faithful copy of the source RDF
+    # and the reified node keeps both its link and its provenance. A concept
+    # therefore carries two definition objects afterwards - the node URI it
+    # always had, and the text read out of it.
+    class ResolveReifiedDefinitions < OntologySubmissionProcess
+
+      # Concepts resolved per round trip to the triple store.
+      PAGE_SIZE = 1_000
+
+      # How many unresolved nodes are described in the log before only counting them.
+      UNRESOLVED_SAMPLE = 25
+
+      # Predicates able to carry the text of a reified definition, best first.
+      # The first one present on a node wins and all of its literals are kept, so
+      # a node holding the same text in several languages yields one definition
+      # per language. Labels come last: on a node they are weak evidence, but a
+      # label is still better than exposing a URI.
+      TEXT_PREDICATES = [
+        'http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+        'http://www.w3.org/2008/05/skos-xl#literalForm',
+        'http://www.w3.org/2004/02/skos/core#definition',
+        'http://purl.obolibrary.org/obo/IAO_0000115',
+        'http://purl.org/dc/terms/description',
+        'http://purl.org/dc/elements/1.1/description',
+        'http://www.w3.org/2000/01/rdf-schema#comment',
+        'http://www.w3.org/2004/02/skos/core#scopeNote',
+        'http://www.w3.org/2004/02/skos/core#note',
+        'http://www.w3.org/2004/02/skos/core#prefLabel',
+        'http://www.w3.org/2000/01/rdf-schema#label'
+      ].freeze
+
+      # Predicates that describe a definition instead of carrying it. They are
+      # never used as text, not even by the last-resort single-candidate rule -
+      # without this list a node holding only dcterms:source would turn its
+      # bibliographic reference into the definition of the concept.
+      PROVENANCE_PREDICATES = [
+        'http://purl.org/dc/terms/source',
+        'http://art.uniroma2.it/ontologies/vocbench#hasSource',
+        'http://purl.org/dc/terms/created',
+        'http://purl.org/dc/terms/modified',
+        'http://purl.org/dc/terms/date',
+        'http://purl.org/dc/terms/issued',
+        'http://purl.org/dc/terms/creator',
+        'http://purl.org/dc/terms/contributor',
+        'http://purl.org/dc/terms/publisher',
+        'http://purl.org/dc/terms/bibliographicCitation',
+        'http://purl.org/dc/terms/identifier',
+        'http://purl.org/dc/elements/1.1/source',
+        'http://purl.org/dc/elements/1.1/creator',
+        'http://purl.org/dc/elements/1.1/date',
+        'http://purl.org/dc/elements/1.1/identifier',
+        'http://www.w3.org/2004/02/skos/core#notation',
+        'http://www.w3.org/2002/07/owl#versionInfo'
+      ].freeze
+
+      # Datatypes a definition text can be written with. Anything else on the
+      # node (dates, counts, flags) is not definition text.
+      TEXT_DATATYPES = [
+        'http://www.w3.org/2001/XMLSchema#string',
+        'http://www.w3.org/2001/XMLSchema#normalizedString',
+        'http://www.w3.org/2001/XMLSchema#token',
+        'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
+        'http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral'
+      ].freeze
+
+      # The heuristics, kept free of any state so they can be exercised on their
+      # own: the best ranked known predicate of the node, or - when the node uses
+      # a vocabulary we do not know about - its single remaining candidate once
+      # provenance is set aside. Anything more ambiguous is left alone rather
+      # than guessed. Takes { predicate => [literal] }, returns the literals
+      # holding the definition text (all of its languages).
+      def self.definition_text(predicates)
+        return [] if predicates.empty?
+
+        best = TEXT_PREDICATES.find { |predicate| predicates.key?(predicate) }
+        return predicates[best] if best
+
+        candidates = predicates.reject { |predicate, _| PROVENANCE_PREDICATES.include?(predicate) }
+        candidates.size == 1 ? candidates.values.first : []
+      end
+
+      def self.text_literal?(object)
+        return false unless object.is_a?(RDF::Literal)
+        return true if object.language
+
+        object.datatype.nil? || TEXT_DATATYPES.include?(object.datatype.to_s)
+      end
+
+      # Assert the text the way the portal writes its own literals: language
+      # tagged when the source is, a plain string otherwise - dropping any exotic
+      # datatype the node used.
+      def self.definition_literal(literal)
+        return RDF::Literal.new(literal.value, language: literal.language) if literal.language
+
+        RDF::Literal.new(literal.value, datatype: RDF::XSD.string)
+      end
+
+      def process(logger, options = {})
+        resolve_reified_definitions(logger, options[:file_path])
+        @submission
+      rescue Exception => e
+        # Enrichment must not sink the parsing: on failure the concepts simply
+        # keep their reified definitions, unresolved. Exception, not
+        # StandardError: Goo raises bare Exceptions out of the append path (its
+        # rapper calls do), and this step runs before indexing - anything that
+        # escapes here costs the submission its whole index.
+        logger.error("Reified definitions resolution failed: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
+        logger.flush
+        @submission
+      end
+
+      private
+
+      def resolve_reified_definitions(logger, file_path)
+        properties = definition_properties
+        save_in_file = file_path.nil? ? nil : File.join(File.dirname(file_path), 'definitions.ttl')
+        stats = { scanned: 0, asserted: 0, unresolved: 0 }
+        fsave = nil
+        after = nil
+
+        time = Benchmark.realtime do
+          loop do
+            concepts = reified_definition_concepts(properties, after)
+            break if concepts.empty?
+
+            triples = resolve_concepts(logger, properties, concepts, stats)
+            stats[:scanned] += concepts.length
+
+            unless triples.empty?
+              data = triples.join("\n")
+              fsave ||= File.open(save_in_file, 'w') if save_in_file
+              fsave&.write(data + "\n")
+              Goo.sparql_data_client.append_triples(@submission.id, data, mime_type = 'application/x-turtle')
+              stats[:asserted] += triples.length
+            end
+
+            after = concepts.last
+            break if concepts.length < PAGE_SIZE
+          end
+        end
+
+        fsave&.close
+        report(logger, stats, save_in_file, time)
+      end
+
+      def report(logger, stats, save_in_file, time)
+        if stats[:scanned].zero?
+          logger.info("No reified definition found in #{@submission.id.to_s}")
+        else
+          logger.info("Resolved #{stats[:asserted]} definitions out of the reified nodes of " \
+                      "#{stats[:scanned]} concepts in #{time.round(2)} sec.")
+          logger.info("Saved resolved definitions in #{save_in_file}") if save_in_file && stats[:asserted].positive?
+        end
+
+        if stats[:unresolved].positive?
+          logger.info("#{stats[:unresolved]} reified nodes carry no recognizable definition text " \
+                      'and were left as is')
+        end
+        logger.flush
+      end
+
+      # skos:definition plus the properties the portal treats as its equivalent,
+      # so a reified definition is picked up whichever one the ontology uses.
+      def definition_properties
+        @submission.bring(:definitionProperty) if @submission.bring?(:definitionProperty)
+
+        properties = [
+          Goo.vocabulary(:skos)[:definition],
+          LinkedData::Utils::Triples.obo_definition_standard,
+          RDF::URI.new('http://purl.obolibrary.org/obo/def')
+        ]
+        properties << RDF::URI.new(@submission.definitionProperty.to_s) unless @submission.definitionProperty.nil?
+        properties.uniq(&:to_s).map(&:to_ntriples)
+      end
+
+      # One page of concepts whose definition is a resource instead of a literal,
+      # starting after the last concept of the previous page. A cursor rather
+      # than an OFFSET: the literals this step asserts never match the pattern
+      # below, but paging that survives a shrinking match set costs nothing here
+      # and does not have to be revisited if that ever stops being true.
+      def reified_definition_concepts(properties, after)
+        filters = ['!isLiteral(?node)']
+        # IRIs order by their string value, so the cursor can compare on str().
+        filters << "str(?concept) > #{RDF::Literal.new(after.to_s).to_ntriples}" if after
+
+        query = <<~SPARQL
+          SELECT DISTINCT ?concept
+          FROM #{@submission.id.to_ntriples}
+          WHERE {
+            VALUES ?definitionProperty { #{properties.join(' ')} }
+            ?concept ?definitionProperty ?node .
+            FILTER(#{filters.join(' && ')})
+          }
+          ORDER BY ?concept
+          LIMIT #{PAGE_SIZE}
+        SPARQL
+
+        concepts = []
+        Goo.sparql_query_client.query(query).each_solution { |sol| concepts << sol[:concept] }
+        concepts
+      end
+
+      def resolve_concepts(logger, properties, concepts, stats)
+        values = concepts.map(&:to_ntriples).join(' ')
+        existing = existing_definitions(properties, values)
+        triples = []
+
+        definition_nodes(properties, values).each do |concept, concept_nodes|
+          concept_nodes.each do |node, predicates|
+            literals = definition_text(predicates)
+
+            if literals.empty?
+              stats[:unresolved] += 1
+              log_unresolved(logger, stats, concept, node, predicates)
+              next
+            end
+
+            literals.each do |literal|
+              # Skip a text the concept already carries as a literal, so nothing
+              # is asserted twice when the source RDF says it both ways.
+              next unless existing[concept].add?([literal.language.to_s.downcase, literal.value])
+
+              triples << LinkedData::Utils::Triples.triple(RDF::URI.new(concept),
+                                                           Goo.vocabulary(:skos)[:definition],
+                                                           definition_literal(literal))
+            end
+          end
+        end
+
+        triples
+      end
+
+      # The literals hanging off the reified nodes of a page of concepts, as
+      # { concept => { node => { predicate => [literal] } } }. Nodes carrying no
+      # literal at all are kept (empty), they are the ones to report.
+      def definition_nodes(properties, values)
+        query = <<~SPARQL
+          SELECT ?concept ?node ?p ?o
+          FROM #{@submission.id.to_ntriples}
+          WHERE {
+            VALUES ?concept { #{values} }
+            VALUES ?definitionProperty { #{properties.join(' ')} }
+            ?concept ?definitionProperty ?node .
+            FILTER(!isLiteral(?node))
+            OPTIONAL {
+              ?node ?p ?o .
+              FILTER(isLiteral(?o))
+            }
+          }
+        SPARQL
+
+        nodes = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = Hash.new { |h3, k3| h3[k3] = [] } } }
+        Goo.sparql_query_client.query(query).each_solution do |sol|
+          predicates = nodes[sol[:concept].to_s][sol[:node].to_s]
+          next if sol[:p].nil?
+
+          predicates[sol[:p].to_s] << sol[:o] if text_literal?(sol[:o])
+        end
+        nodes
+      end
+
+      # The definitions a page of concepts already holds as literals, so nothing
+      # gets asserted twice.
+      def existing_definitions(properties, values)
+        query = <<~SPARQL
+          SELECT ?concept ?definition
+          FROM #{@submission.id.to_ntriples}
+          WHERE {
+            VALUES ?concept { #{values} }
+            VALUES ?definitionProperty { #{properties.join(' ')} }
+            ?concept ?definitionProperty ?definition .
+            FILTER(isLiteral(?definition))
+          }
+        SPARQL
+
+        existing = Hash.new { |h, k| h[k] = Set.new }
+        Goo.sparql_query_client.query(query).each_solution do |sol|
+          existing[sol[:concept].to_s] << [sol[:definition].language.to_s.downcase, sol[:definition].value]
+        end
+        existing
+      end
+
+      def definition_text(predicates)
+        self.class.definition_text(predicates)
+      end
+
+      def text_literal?(object)
+        self.class.text_literal?(object)
+      end
+
+      def definition_literal(literal)
+        self.class.definition_literal(literal)
+      end
+
+      def log_unresolved(logger, stats, concept, node, predicates)
+        return if stats[:unresolved] > UNRESOLVED_SAMPLE
+
+        described = predicates.keys.empty? ? 'no literal in this graph' : predicates.keys.join(', ')
+        logger.info("No definition text on #{node}, reified definition of #{concept} (#{described})")
+      end
+
+    end
+  end
+end

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_reified_definitions.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_reified_definitions.rb
@@ -185,6 +185,13 @@ module LinkedData
 
       # skos:definition plus the properties the portal treats as its equivalent,
       # so a reified definition is picked up whichever one the ontology uses.
+      #
+      # The queries below restrict on these with FILTER(?p IN (...)) rather than
+      # a VALUES block: 4store parses VALUES and then silently ignores it, in
+      # every position. That turns each pattern into an unrestricted one, and a
+      # step meant to read a few hundred reified nodes instead walks every
+      # skos:broader, skos:inScheme and rdf:type of every concept and asserts
+      # the prefLabel it finds there as a definition.
       def definition_properties
         @submission.bring(:definitionProperty) if @submission.bring?(:definitionProperty)
 
@@ -203,7 +210,7 @@ module LinkedData
       # below, but paging that survives a shrinking match set costs nothing here
       # and does not have to be revisited if that ever stops being true.
       def reified_definition_concepts(properties, after)
-        filters = ['!isLiteral(?node)']
+        filters = ["?definitionProperty IN (#{properties.join(', ')})", '!isLiteral(?node)']
         # IRIs order by their string value, so the cursor can compare on str().
         filters << "str(?concept) > #{RDF::Literal.new(after.to_s).to_ntriples}" if after
 
@@ -211,7 +218,6 @@ module LinkedData
           SELECT DISTINCT ?concept
           FROM #{@submission.id.to_ntriples}
           WHERE {
-            VALUES ?definitionProperty { #{properties.join(' ')} }
             ?concept ?definitionProperty ?node .
             FILTER(#{filters.join(' && ')})
           }
@@ -225,11 +231,11 @@ module LinkedData
       end
 
       def resolve_concepts(logger, properties, concepts, stats)
-        values = concepts.map(&:to_ntriples).join(' ')
-        existing = existing_definitions(properties, values)
+        concept_list = concepts.map(&:to_ntriples).join(', ')
+        existing = existing_definitions(properties, concept_list)
         triples = []
 
-        definition_nodes(properties, values).each do |concept, concept_nodes|
+        definition_nodes(properties, concept_list).each do |concept, concept_nodes|
           concept_nodes.each do |node, predicates|
             literals = definition_text(predicates)
 
@@ -257,15 +263,15 @@ module LinkedData
       # The literals hanging off the reified nodes of a page of concepts, as
       # { concept => { node => { predicate => [literal] } } }. Nodes carrying no
       # literal at all are kept (empty), they are the ones to report.
-      def definition_nodes(properties, values)
+      def definition_nodes(properties, concept_list)
         query = <<~SPARQL
           SELECT ?concept ?node ?p ?o
           FROM #{@submission.id.to_ntriples}
           WHERE {
-            VALUES ?concept { #{values} }
-            VALUES ?definitionProperty { #{properties.join(' ')} }
             ?concept ?definitionProperty ?node .
-            FILTER(!isLiteral(?node))
+            FILTER(?concept IN (#{concept_list})
+                   && ?definitionProperty IN (#{properties.join(', ')})
+                   && !isLiteral(?node))
             OPTIONAL {
               ?node ?p ?o .
               FILTER(isLiteral(?o))
@@ -285,15 +291,15 @@ module LinkedData
 
       # The definitions a page of concepts already holds as literals, so nothing
       # gets asserted twice.
-      def existing_definitions(properties, values)
+      def existing_definitions(properties, concept_list)
         query = <<~SPARQL
           SELECT ?concept ?definition
           FROM #{@submission.id.to_ntriples}
           WHERE {
-            VALUES ?concept { #{values} }
-            VALUES ?definitionProperty { #{properties.join(' ')} }
             ?concept ?definitionProperty ?definition .
-            FILTER(isLiteral(?definition))
+            FILTER(?concept IN (#{concept_list})
+                   && ?definitionProperty IN (#{properties.join(', ')})
+                   && isLiteral(?definition))
           }
         SPARQL
 

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -5,6 +5,7 @@ module LinkedData
       ################################################################
       # Possible options with their defaults:
       #   process_rdf       = false
+      #   resolve_reified_definitions = follows process_rdf
       #   index_search      = false
       #   index_properties  = false
       #   index_commit      = false
@@ -43,6 +44,10 @@ module LinkedData
             @submission.generate_missing_labels(logger) if generate_missing_labels?(options)
 
             @submission.generate_obsolete_classes(logger) if generate_obsolete_classes?(options)
+
+            # Before indexing: the definitions it materializes have to reach Solr
+            # with the rest of the concept.
+            @submission.resolve_reified_definitions(logger) if resolve_reified_definitions?(options)
 
             if !parsed && (index_search?(options) || index_properties?(options) || index_all_data?(options))
               raise StandardError, "The submission #{@submission.ontology.acronym}/submissions/#{@submission.submissionId}
@@ -89,6 +94,10 @@ module LinkedData
 
       def generate_obsolete_classes?(options)
         options[:generate_obsolete_classes].nil? && process_rdf?(options) || options[:generate_obsolete_classes].eql?(true)
+      end
+
+      def resolve_reified_definitions?(options)
+        options[:resolve_reified_definitions].nil? && process_rdf?(options) || options[:resolve_reified_definitions].eql?(true)
       end
       
       def index_all_data?(options)

--- a/test/models/skos/test_resolve_reified_definitions.rb
+++ b/test/models/skos/test_resolve_reified_definitions.rb
@@ -23,8 +23,27 @@ class TestResolveReifiedDefinitions < LinkedData::TestOntologyCommon
   DCT_SOURCE = 'http://purl.org/dc/terms/source'
   SKOS_PREFLABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel'
 
-  # Parsed with the step disabled: the test drives it explicitly so it can
-  # observe the graph before, after, and after a second run.
+  # A concept of the same fixture carrying no definition at all: its only
+  # resource valued properties are skos:broader, skos:inScheme and rdf:type.
+  # None of them is a reified definition, so the step has to leave it alone.
+  LINKED_CONCEPT = 'http://opendata.inrae.fr/thesaurusINRAE/c_0015b5e0'
+
+  # What those links turn into when the definition properties of the queries do
+  # not reach the backend: the labels of the broader concept, the labels of the
+  # concept schemes, and - through rdf:type - the definition SKOS gives to
+  # skos:Concept, which lands on every concept of the ontology at once.
+  LEAKED_TEXTS = {
+    'cell division' => 'skos:broader c_9399',
+    'division cellulaire' => 'skos:broader c_9399',
+    'BIO cell biology' => 'skos:inScheme mt_64',
+    'Thésaurus INRAE' => 'skos:inScheme thesaurusINRAE',
+    'An idea or notion; a unit of thought.' => 'rdf:type skos:Concept'
+  }.freeze
+
+  # Parsed with the step disabled, so everything the tests read afterwards can
+  # only have come from the step. It runs once, here rather than inside a test:
+  # minitest orders tests at random, so none of them may depend on being the one
+  # that runs it.
   def self.before_suite
     LinkedData::TestCase.backend_4s_delete
     self.new('').submission_parse('INRAETHES', 'Testing skos',
@@ -32,6 +51,16 @@ class TestResolveReifiedDefinitions < LinkedData::TestOntologyCommon
                                   1,
                                   process_rdf: true, extract_metadata: false, generate_missing_labels: false,
                                   resolve_reified_definitions: false)
+
+    test = self.new('')
+    sub = test.submission
+    sub.bring_remaining # the step writes its triples next to the master file
+    unless test.literal_definitions(sub, REIFIED_CONCEPT).empty?
+      raise "#{REIFIED_CONCEPT} already carries a literal definition once parsed, " \
+            'the assertions on the resolved text would prove nothing'
+    end
+
+    sub.resolve_reified_definitions(Logger.new(TestLogFile.new))
   end
 
   def submission
@@ -96,11 +125,6 @@ class TestResolveReifiedDefinitions < LinkedData::TestOntologyCommon
   # anything.
   def test_resolve_reified_definitions
     sub = submission
-    sub.bring_remaining # the step writes its triples next to the master file
-    assert_empty literal_definitions(sub, REIFIED_CONCEPT),
-                 'the fixture concept starts with no literal definition'
-
-    sub.resolve_reified_definitions(Logger.new(TestLogFile.new))
 
     definitions = literal_definitions(sub, REIFIED_CONCEPT)
     assert_equal 1, definitions.length
@@ -124,13 +148,36 @@ class TestResolveReifiedDefinitions < LinkedData::TestOntologyCommon
     assert_includes values, REIFIED_NODE, 'the node URI is left where the ontology put it'
 
     # Replayed on an already enriched graph, the step adds nothing.
+    sub.bring_remaining # the step writes its triples next to the master file
     sub.resolve_reified_definitions(Logger.new(TestLogFile.new))
     assert_equal 1, literal_definitions(sub, REIFIED_CONCEPT).length
   ensure
     RequestStore.store[:requested_lang] = nil
   end
 
-  private
+  # The other half of the pattern: only the definition properties lead to a
+  # reified definition. A concept whose resources are ordinary SKOS links keeps
+  # no definition out of them - the labels sitting on a broader concept or on a
+  # concept scheme are not its definition.
+  #
+  # This is what breaks first when the property restriction of the queries does
+  # not reach the backend, and it breaks silently: every skos:broader,
+  # skos:inScheme and rdf:type reads as a reified definition, the prefLabel of
+  # its target reads as the text, and the step writes two orders of magnitude
+  # more definitions than the ontology has.
+  def test_ordinary_links_are_not_reified_definitions
+    sub = submission
+
+    assert_empty definition_objects(sub, LINKED_CONCEPT),
+                 "#{LINKED_CONCEPT} has no definition in the fixture and gets none from the step"
+
+    # Each text named with the link it would have come through, so a failure
+    # says which one leaked rather than just counting definitions.
+    resolved = literal_definitions(sub, LINKED_CONCEPT).map(&:value)
+    LEAKED_TEXTS.each do |text, link|
+      refute_includes resolved, text, "#{link} of #{LINKED_CONCEPT} is not a reified definition"
+    end
+  end
 
   def definition_objects(sub, concept)
     query = <<~SPARQL

--- a/test/models/skos/test_resolve_reified_definitions.rb
+++ b/test/models/skos/test_resolve_reified_definitions.rb
@@ -1,0 +1,158 @@
+require_relative '../test_ontology_common'
+require 'logger'
+
+# Tests for ResolveReifiedDefinitions, the processing step that turns a reified
+# definition into a plain skos:definition literal on the concept.
+#
+# The INRAE Thesaurus fixture carries the canonical shape:
+#   c_01cd9294 --skos:definition--> note_a8fb2e24
+#   note_a8fb2e24  rdf:value  "Pratique qui se définit..."@fr
+#                  dct:source "Dérivée de J. Boiffin..."
+# so it exercises both halves of the heuristics: rdf:value is picked as the
+# text, dcterms:source is provenance and must never become a definition.
+class TestResolveReifiedDefinitions < LinkedData::TestOntologyCommon
+
+  RESOLVER = LinkedData::Services::ResolveReifiedDefinitions
+
+  REIFIED_CONCEPT = 'http://opendata.inrae.fr/thesaurusINRAE/c_01cd9294'
+  REIFIED_NODE    = 'http://opendata.inrae.fr/thesaurusINRAE/note_a8fb2e24'
+  EXPECTED_TEXT_START = "Pratique qui se définit comme l'ensemble des processus"
+  EXPECTED_SOURCE_START = 'Dérivée de J. Boiffin'
+  SKOS_DEFINITION = 'http://www.w3.org/2004/02/skos/core#definition'
+  RDF_VALUE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value'
+  DCT_SOURCE = 'http://purl.org/dc/terms/source'
+  SKOS_PREFLABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel'
+
+  # Parsed with the step disabled: the test drives it explicitly so it can
+  # observe the graph before, after, and after a second run.
+  def self.before_suite
+    LinkedData::TestCase.backend_4s_delete
+    self.new('').submission_parse('INRAETHES', 'Testing skos',
+                                  'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
+                                  1,
+                                  process_rdf: true, extract_metadata: false, generate_missing_labels: false,
+                                  resolve_reified_definitions: false)
+  end
+
+  def submission
+    LinkedData::Models::Ontology.find('INRAETHES').first.latest_submission
+  end
+
+  # Backend-free: rdf:value wins over the provenance sitting next to it, and all
+  # of its languages are kept.
+  def test_text_predicate_ranking
+    text_fr = RDF::Literal.new('texte', language: :fr)
+    text_en = RDF::Literal.new('text', language: :en)
+    source = RDF::Literal.new('Boiffin, 2020')
+
+    literals = RESOLVER.definition_text({ RDF_VALUE => [text_fr, text_en], DCT_SOURCE => [source] })
+    assert_equal %w[texte text], literals.map(&:value), 'rdf:value carries the text, in every language'
+
+    # A lower ranked predicate is only used when no better one is on the node.
+    label_only = RESOLVER.definition_text({ SKOS_PREFLABEL => [text_fr] })
+    assert_equal ['texte'], label_only.map(&:value)
+
+    both = RESOLVER.definition_text({ SKOS_PREFLABEL => [text_en], RDF_VALUE => [text_fr] })
+    assert_equal ['texte'], both.map(&:value), 'rdf:value outranks a label'
+  end
+
+  # Backend-free: provenance alone is never turned into a definition, and an
+  # unknown node too ambiguous to read is left alone rather than guessed.
+  def test_provenance_is_never_a_definition
+    assert_empty RESOLVER.definition_text({ DCT_SOURCE => [RDF::Literal.new('Boiffin, 2020')] })
+    assert_empty RESOLVER.definition_text({})
+
+    unknown = 'http://example.org/note'
+    other = 'http://example.org/comment'
+    assert_equal ['texte'],
+                 RESOLVER.definition_text({ unknown => [RDF::Literal.new('texte')],
+                                            DCT_SOURCE => [RDF::Literal.new('Boiffin, 2020')] }).map(&:value),
+                 'a single candidate left after provenance is the definition'
+    assert_empty RESOLVER.definition_text({ unknown => [RDF::Literal.new('a')], other => [RDF::Literal.new('b')] }),
+                 'two unknown candidates are ambiguous, nothing is guessed'
+  end
+
+  # Backend-free: only text-shaped literals are candidates, and what gets
+  # asserted keeps the language while dropping exotic datatypes.
+  def test_literal_handling
+    assert RESOLVER.text_literal?(RDF::Literal.new('texte', language: :fr))
+    assert RESOLVER.text_literal?(RDF::Literal.new('texte'))
+    refute RESOLVER.text_literal?(RDF::Literal.new(DateTime.now)), 'a date is not definition text'
+    refute RESOLVER.text_literal?(RDF::Literal.new(42))
+    refute RESOLVER.text_literal?(RDF::URI.new(REIFIED_NODE))
+
+    tagged = RESOLVER.definition_literal(RDF::Literal.new('texte', language: :fr))
+    assert_equal 'texte', tagged.value
+    assert_equal :fr, tagged.language
+
+    exotic = RESOLVER.definition_literal(RDF::Literal.new('texte', datatype: RDF::XSD.token))
+    assert_equal 'texte', exotic.value
+    assert_equal RDF::XSD.string, exotic.datatype
+  end
+
+  # The whole step against the triple store: a reified definition becomes a
+  # literal on the concept, nothing is removed from the graph, the provenance is
+  # not mistaken for the text, and replaying the step does not duplicate
+  # anything.
+  def test_resolve_reified_definitions
+    sub = submission
+    sub.bring_remaining # the step writes its triples next to the master file
+    assert_empty literal_definitions(sub, REIFIED_CONCEPT),
+                 'the fixture concept starts with no literal definition'
+
+    sub.resolve_reified_definitions(Logger.new(TestLogFile.new))
+
+    definitions = literal_definitions(sub, REIFIED_CONCEPT)
+    assert_equal 1, definitions.length
+    definition = definitions.first
+    assert definition.value.start_with?(EXPECTED_TEXT_START)
+    assert_equal :fr, definition.language, 'the language of the reified text is kept'
+    refute definition.value.start_with?(EXPECTED_SOURCE_START), 'dcterms:source is not the definition'
+
+    # The step only appends: the reified triple and the node it points at are
+    # both still there.
+    assert_includes definition_objects(sub, REIFIED_CONCEPT).map(&:to_s), REIFIED_NODE
+    assert node_still_described?(sub, REIFIED_NODE)
+
+    # The attribute reports the graph as it is: the text the step resolved, and
+    # the node URI the ontology put there, side by side.
+    RequestStore.store[:requested_lang] = :FR
+    cls = LinkedData::Models::Class.find(REIFIED_CONCEPT).in(sub).include(:definition).first
+    values = cls.definition.map(&:to_s)
+    assert values.any? { |value| value.start_with?(EXPECTED_TEXT_START) },
+           'the concept exposes the resolved text through its definition'
+    assert_includes values, REIFIED_NODE, 'the node URI is left where the ontology put it'
+
+    # Replayed on an already enriched graph, the step adds nothing.
+    sub.resolve_reified_definitions(Logger.new(TestLogFile.new))
+    assert_equal 1, literal_definitions(sub, REIFIED_CONCEPT).length
+  ensure
+    RequestStore.store[:requested_lang] = nil
+  end
+
+  private
+
+  def definition_objects(sub, concept)
+    query = <<~SPARQL
+      SELECT ?definition
+      FROM <#{sub.id}>
+      WHERE { <#{concept}> <#{SKOS_DEFINITION}> ?definition . }
+    SPARQL
+    objects = []
+    Goo.sparql_query_client.query(query).each_solution { |sol| objects << sol[:definition] }
+    objects
+  end
+
+  def literal_definitions(sub, concept)
+    definition_objects(sub, concept).select { |o| o.is_a?(RDF::Literal) }
+  end
+
+  def node_still_described?(sub, node)
+    query = <<~SPARQL
+      SELECT ?p FROM <#{sub.id}> WHERE { <#{node}> ?p ?o . } LIMIT 1
+    SPARQL
+    described = false
+    Goo.sparql_query_client.query(query).each_solution { described = true }
+    described
+  end
+end


### PR DESCRIPTION
Materialize the text carried by reified definition nodes as plain skos:definition literals on the concept itself.

Thesauri such as AGROVOC or the INRAE Thesaurus do not attach the definition as a literal, they reify it onto a dedicated node:
```
  <c_01cd9294>    skos:definition <note_a8fb2e24> .
  <note_a8fb2e24> rdf:value       "Pratique qui se definit..."@fr ;
                  dcterms:source  "Derivee de J. Boiffin..." .
```
The definition then reaches the portal as a bare URI: nothing to display, nothing to index, nothing to annotate. This step follows those nodes, picks the predicate holding the text with a ranked list of heuristics (rdf:value, skosxl:literalForm, ... down to skos:prefLabel/rdfs:label) and asserts the text back on the concept as a skos:definition literal, keeping the language tag.

Nothing is removed: like every other step of the pipeline this one only appends, so the submission graph stays a faithful copy of the source RDF and the reified node keeps both its link and its provenance. A concept therefore carries two definition objects afterwards - the node URI it always had, and the text read out of it.