### PR TITLE
fix: delete definitions.ttl when archiving a submission

### DIFF
--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb
@@ -2,7 +2,7 @@ module LinkedData
   module Services
     class OntologySubmissionArchiver < OntologySubmissionProcess
 
-      FILES_TO_DELETE = ['labels.ttl', 'mappings.ttl', 'obsolete.ttl', 'owlapi.xrdf', 'errors.log']
+      FILES_TO_DELETE = ['labels.ttl', 'mappings.ttl', 'obsolete.ttl', 'definitions.ttl', 'owlapi.xrdf', 'errors.log']
       FOLDERS_TO_DELETE = ['unzipped']
       FILE_SIZE_ZIPPING_THRESHOLD = 100 * 1024 * 1024 # 100MB
 


### PR DESCRIPTION
`ResolveReifiedDefinitions` writes a `definitions.ttl` next to the master file (`submission_reified_definitions.rb:140`), alongside the other generated artifacts like `labels.ttl` and `obsolete.ttl`.

It was missing from `OntologySubmissionArchiver::FILES_TO_DELETE`, so unlike its siblings it survived archiving and kept occupying disk in every archived submission folder.

Adds it to the list, next to the other generated `.ttl` files.